### PR TITLE
feat: fix rocket angle and add target mini-game

### DIFF
--- a/src/AudioManager.js
+++ b/src/AudioManager.js
@@ -47,4 +47,18 @@ export class AudioManager {
   pop() {
     this._osc(50, 'sine', 0.15, 0.45, 350);
   }
+
+  explosion() {
+    // Satisfying hit sound: low boom + high sparkle
+    this._osc(60, 'sine', 0.4, 0.45, 250);
+    this._osc(800, 'sine', 0.2, 0.15, 1200);
+    setTimeout(() => {
+      this._osc(523, 'sine', 0.15, 0.2);
+      this._osc(659, 'sine', 0.15, 0.18);
+    }, 80);
+    setTimeout(() => {
+      this._osc(784, 'sine', 0.15, 0.15);
+      this._osc(1047, 'sine', 0.12, 0.12);
+    }, 160);
+  }
 }

--- a/src/World.js
+++ b/src/World.js
@@ -7,6 +7,7 @@ import { Ball } from './actors/Ball.js';
 import { Rocket } from './actors/Rocket.js';
 import { Star } from './actors/Star.js';
 import { Butterfly } from './actors/Butterfly.js';
+import { Target } from './actors/Target.js';
 
 export class World {
   constructor(canvas, ctx, input, audio) {
@@ -24,6 +25,10 @@ export class World {
     this._prevPointerIds = new Set();
 
     this.emergentTimer = 6 + Math.random() * 10;
+    this.targetTimer = 3;   // spawn first target after 3 seconds
+    this.score = 0;
+    this.scoreDisplay = 0;  // animated score display
+    this.scorePop = 0;      // scale pop effect on score change
 
     this._spawn();
   }
@@ -54,6 +59,13 @@ export class World {
       const b = new Butterfly(w * (0.25 + i * 0.5), h * 0.35);
       b._pickNewTarget();
       this.actors.push(b);
+    }
+
+    // Initial targets to aim at
+    for (let i = 0; i < 3; i++) {
+      const tx = w * (0.2 + i * 0.3);
+      const ty = h * (0.1 + Math.random() * 0.25);
+      this.actors.push(new Target(tx, ty));
     }
   }
 
@@ -127,9 +139,35 @@ export class World {
     for (const actor of this.actors) {
       actor.update(dt, this.w, this.h, this.particles);
     }
+
+    // ── Rocket ↔ Target collisions ──────────────────────
+    const rockets = this.actors.filter(a => a instanceof Rocket && a.launched);
+    const targets = this.actors.filter(a => a instanceof Target && !a.hit);
+    for (const rocket of rockets) {
+      for (const target of targets) {
+        const dist = Math.hypot(rocket.x - target.x, rocket.y - target.y);
+        if (dist < (rocket.size + target.size) * 0.45) {
+          target.explode(this.particles, this.audio);
+          this.score += 1;
+          this.scorePop = 1;
+        }
+      }
+    }
+
     this.actors = this.actors.filter(a => a.alive);
 
     this.particles.update(dt);
+
+    // ── Target spawning ─────────────────────────────────
+    this.targetTimer -= dt;
+    if (this.targetTimer <= 0) {
+      this._spawnTarget();
+      this.targetTimer = 4 + Math.random() * 5;
+    }
+
+    // ── Score animation ─────────────────────────────────
+    this.scoreDisplay += (this.score - this.scoreDisplay) * dt * 8;
+    this.scorePop = Math.max(0, this.scorePop - dt * 3);
 
     // ── Emergent events ───────────────────────────────────
     this.emergentTimer -= dt;
@@ -171,6 +209,15 @@ export class World {
     }
   }
 
+  _spawnTarget() {
+    const margin = 80;
+    const x = margin + Math.random() * (this.w - margin * 2);
+    // Targets appear in the sky area (top 55% of screen)
+    const y = margin + Math.random() * (this.h * 0.45);
+    const t = new Target(x, y);
+    this.actors.push(t);
+  }
+
   _rainbowBurst() {
     this.particles.burst(this.w / 2, this.h * 0.4, 35, {
       colors: ['#FF0000', '#FF7F00', '#FFFF00', '#00DD00', '#0077FF', '#8B00FF'],
@@ -194,5 +241,25 @@ export class World {
 
     // Key labels — topmost
     for (const l of this.keyLabels) l.draw(ctx);
+
+    // ── Score display ───────────────────────────────────
+    if (this.score > 0) {
+      const displayScore = Math.round(this.scoreDisplay);
+      const popScale = 1 + this.scorePop * 0.4;
+      ctx.save();
+      ctx.translate(w / 2, 38);
+      ctx.scale(popScale, popScale);
+      ctx.font = 'bold 32px sans-serif';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillStyle = 'rgba(0, 0, 0, 0.3)';
+      ctx.fillText(`💥 ${displayScore}`, 2, 2);
+      ctx.fillStyle = '#FFD700';
+      ctx.strokeStyle = 'rgba(0, 0, 0, 0.5)';
+      ctx.lineWidth = 3;
+      ctx.strokeText(`💥 ${displayScore}`, 0, 0);
+      ctx.fillText(`💥 ${displayScore}`, 0, 0);
+      ctx.restore();
+    }
   }
 }

--- a/src/actors/Rocket.js
+++ b/src/actors/Rocket.js
@@ -10,6 +10,9 @@ export class Rocket extends Actor {
     this.launched = false;
     this.launchVY = 0;
     this.trailTimer = 0;
+    // The 🚀 emoji faces upper-right (~45° from vertical).
+    // Rotate -45° so it points straight up by default.
+    this.rotationOffset = -Math.PI / 4;
   }
 
   update(dt, w, h, particles) {
@@ -22,7 +25,7 @@ export class Rocket extends Actor {
       this.launchVY += 120 * dt; // gravity
       this.vy = this.launchVY;
 
-      // Emit trail
+      // Emit trail from the bottom of the rocket
       if (this.trailTimer <= 0) {
         this.trailTimer = 0.03;
         particles.trail(this.x, this.y + this.size * 0.5, '#FF6B00', { size: 12, life: 0.55, gravity: 30 });
@@ -48,6 +51,7 @@ export class Rocket extends Actor {
   draw(ctx) {
     ctx.save();
     ctx.translate(this.x, this.y);
+    ctx.rotate(this.rotationOffset);
     ctx.font = `${this.size}px serif`;
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';

--- a/src/actors/Target.js
+++ b/src/actors/Target.js
@@ -1,0 +1,65 @@
+import { Actor } from './Actor.js';
+
+const EMOJIS = ['🎈', '🎯', '🪐', '👾', '⭐'];
+
+export class Target extends Actor {
+  constructor(x, y) {
+    super(x, y);
+    this.size = 60;
+    this.emoji = EMOJIS[Math.floor(Math.random() * EMOJIS.length)];
+    this.bobTime = Math.random() * Math.PI * 2;
+    this.bobAmplitude = 8 + Math.random() * 10;
+    this.baseY = y;
+    this.scale = 0;        // pop-in animation
+    this.scaleTarget = 1;
+    this.lifetime = 15 + Math.random() * 10; // seconds before fading away
+    this.fadeTimer = 0;
+    this.hit = false;
+  }
+
+  update(dt, w, h, particles) {
+    super.update(dt, w, h);
+
+    // Pop-in animation
+    this.scale += (this.scaleTarget - this.scale) * dt * 5;
+
+    // Gentle bobbing
+    this.bobTime += dt * 1.2;
+    this.y = this.baseY + Math.sin(this.bobTime) * this.bobAmplitude;
+
+    // Lifetime countdown
+    this.lifetime -= dt;
+    if (this.lifetime <= 0) {
+      this.fadeTimer += dt;
+      this.scaleTarget = 0;
+      if (this.scale < 0.05) this.alive = false;
+    }
+  }
+
+  draw(ctx) {
+    if (this.scale < 0.01) return;
+    ctx.save();
+    ctx.translate(this.x, this.y);
+    ctx.scale(this.scale, this.scale);
+    ctx.font = `${this.size}px serif`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(this.emoji, 0, 0);
+    ctx.restore();
+  }
+
+  explode(particles, audio) {
+    this.hit = true;
+    this.alive = false;
+
+    // Big celebration burst
+    particles.burst(this.x, this.y, 25, {
+      colors: ['#FFD700', '#FF6B6B', '#4ECDC4', '#FF9FF3', '#FF4444', '#FFA500'],
+      minSpeed: 100, maxSpeed: 350,
+      gravity: 130,
+      minSize: 5, maxSize: 16,
+    });
+
+    audio.explosion();
+  }
+}


### PR DESCRIPTION
## Summary
- **Fix rocket rotation**: Rotate 🚀 emoji by -45° so it points straight up during flight instead of diagonally
- **Add target mini-game**: Colorful targets (🎈🎯🪐👾⭐) spawn in the sky area — hit them with rockets for explosions
- **Score counter**: Golden score display appears at top center after first hit, with pop animation
- **Explosion effects**: Big particle burst + multi-layered sound on target hit

## Test plan
- [ ] Verify rocket emoji points straight up when idle and during flight
- [ ] Tap rocket to launch — confirm it flies toward targets in the sky
- [ ] Hit a target — verify particle explosion, sound, and score increment
- [ ] Targets spawn periodically and fade away after ~15-25 seconds
- [ ] Score display appears after first hit with pop animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)