### PR TITLE
feat: launch pad with aiming and moving targets

### DIFF
--- a/src/World.js
+++ b/src/World.js
@@ -8,6 +8,7 @@ import { Rocket } from './actors/Rocket.js';
 import { Star } from './actors/Star.js';
 import { Butterfly } from './actors/Butterfly.js';
 import { Target } from './actors/Target.js';
+import { LaunchPad } from './actors/LaunchPad.js';
 
 export class World {
   constructor(canvas, ctx, input, audio) {
@@ -25,10 +26,12 @@ export class World {
     this._prevPointerIds = new Set();
 
     this.emergentTimer = 6 + Math.random() * 10;
-    this.targetTimer = 3;   // spawn first target after 3 seconds
+    this.targetTimer = 3;
     this.score = 0;
-    this.scoreDisplay = 0;  // animated score display
-    this.scorePop = 0;      // scale pop effect on score change
+    this.scoreDisplay = 0;
+    this.scorePop = 0;
+
+    this.launchPad = null;
 
     this._spawn();
   }
@@ -49,7 +52,9 @@ export class World {
     this.actors.push(new Ball(w * 0.28, h * 0.4));
     this.actors.push(new Ball(w * 0.72, h * 0.32));
 
-    this.actors.push(new Rocket(w * 0.5, h * 0.28));
+    // Launch pad at bottom center, above the road
+    this.launchPad = new LaunchPad(w * 0.5, h * 0.72);
+    this.actors.push(this.launchPad);
 
     for (let i = 0; i < 3; i++) {
       this.actors.push(new Star(w * (0.18 + i * 0.32), h * (0.12 + Math.random() * 0.2)));
@@ -61,16 +66,50 @@ export class World {
       this.actors.push(b);
     }
 
-    // Initial targets to aim at
+    // Initial targets
     for (let i = 0; i < 3; i++) {
-      const tx = w * (0.2 + i * 0.3);
-      const ty = h * (0.1 + Math.random() * 0.25);
+      const tx = w * (0.15 + i * 0.35);
+      const ty = h * (0.08 + Math.random() * 0.25);
       this.actors.push(new Target(tx, ty));
     }
   }
 
+  _launchRocket(tapX, tapY) {
+    const pad = this.launchPad;
+    if (!pad || !pad.ready) return;
+
+    const startX = pad.x;
+    const startY = pad.y - 25; // launch from top of pad
+    const angle = Math.atan2(tapY - startY, tapX - startX);
+
+    // Don't launch downward — only allow angles pointing upward
+    if (angle >= 0) return;
+
+    const speed = 650;
+    const rocket = new Rocket(startX, startY, angle, speed);
+    this.actors.push(rocket);
+    pad.launch();
+
+    // Launch burst
+    this.particles.burst(startX, startY, 14, {
+      colors: ['#FF6B00', '#FFE44D', '#FF4444', '#FFA500'],
+      minSpeed: 60, maxSpeed: 180, gravity: 160,
+    });
+
+    this.audio.launch();
+  }
+
   update(dt) {
     this.bg.update(dt);
+
+    // ── Pointer tracking for aim line ──────────────────
+    const pointers = this.input.getActivePointers();
+    if (pointers.length > 0 && this.launchPad) {
+      // Use the first pointer for aiming
+      this.launchPad.setAim(pointers[0].x, pointers[0].y);
+    } else if (this.launchPad) {
+      this.launchPad.clearAim();
+    }
 
     // ── Taps ─────────────────────────────────────────────
     const taps = this.input.consumeTaps();
@@ -79,22 +118,28 @@ export class World {
     for (const tap of taps) {
       let hit = false;
       for (let i = this.actors.length - 1; i >= 0; i--) {
-        if (this.actors[i].hitTest(tap.x, tap.y)) {
-          this.actors[i].onTap(tap.x, tap.y, this.particles, this.audio);
+        const actor = this.actors[i];
+        // Skip launch pad and rockets for hit testing — they don't consume taps
+        if (actor instanceof LaunchPad || actor instanceof Rocket) continue;
+        if (actor.hitTest(tap.x, tap.y)) {
+          actor.onTap(tap.x, tap.y, this.particles, this.audio);
           hit = true;
           break;
         }
       }
+
+      // Any tap that doesn't hit another actor → launch a rocket toward that point
       if (!hit) {
-        this.particles.burst(tap.x, tap.y, 10, {
+        this._launchRocket(tap.x, tap.y);
+        // Also show particles at tap point
+        this.particles.burst(tap.x, tap.y, 8, {
           colors: ['#FFD700', '#FF6B6B', '#4ECDC4', '#FF9FF3', '#A8E6CF'],
-          minSpeed: 35, maxSpeed: 110, gravity: 120,
+          minSpeed: 25, maxSpeed: 80, gravity: 120,
         });
       }
     }
 
     // ── Drawing ───────────────────────────────────────────
-    const pointers = this.input.getActivePointers();
     const currentIds = new Set(pointers.map(p => p.id));
 
     for (const p of pointers) {
@@ -118,7 +163,6 @@ export class World {
 
       this.keyLabels.push(label);
 
-      // Particle burst around where the label appears
       this.particles.burst(label.x, label.y, 18, {
         colors: [
           `hsl(${label.hue}, 100%, 60%)`,
@@ -148,6 +192,7 @@ export class World {
         const dist = Math.hypot(rocket.x - target.x, rocket.y - target.y);
         if (dist < (rocket.size + target.size) * 0.45) {
           target.explode(this.particles, this.audio);
+          rocket.alive = false; // rocket consumed on hit
           this.score += 1;
           this.scorePop = 1;
         }
@@ -162,7 +207,7 @@ export class World {
     this.targetTimer -= dt;
     if (this.targetTimer <= 0) {
       this._spawnTarget();
-      this.targetTimer = 4 + Math.random() * 5;
+      this.targetTimer = 3 + Math.random() * 4;
     }
 
     // ── Score animation ─────────────────────────────────
@@ -212,8 +257,7 @@ export class World {
   _spawnTarget() {
     const margin = 80;
     const x = margin + Math.random() * (this.w - margin * 2);
-    // Targets appear in the sky area (top 55% of screen)
-    const y = margin + Math.random() * (this.h * 0.45);
+    const y = margin + Math.random() * (this.h * 0.40);
     const t = new Target(x, y);
     this.actors.push(t);
   }

--- a/src/actors/LaunchPad.js
+++ b/src/actors/LaunchPad.js
@@ -1,0 +1,95 @@
+import { Actor } from './Actor.js';
+
+export class LaunchPad extends Actor {
+  constructor(x, y) {
+    super(x, y);
+    this.size = 90;
+    this.aimAngle = -Math.PI / 2; // default: straight up
+    this.aimActive = false;
+    this.reloadTimer = 0;
+    this.reloadTime = 0.8; // seconds between launches
+    this.padWidth = 120;
+    this.padHeight = 18;
+  }
+
+  get ready() {
+    return this.reloadTimer <= 0;
+  }
+
+  setAim(targetX, targetY) {
+    this.aimAngle = Math.atan2(targetY - this.y, targetX - this.x);
+    // Clamp so you can't shoot downward
+    if (this.aimAngle > -0.15) this.aimAngle = -0.15;
+    if (this.aimAngle < -Math.PI + 0.15) this.aimAngle = -Math.PI + 0.15;
+    this.aimActive = true;
+  }
+
+  clearAim() {
+    this.aimActive = false;
+  }
+
+  launch() {
+    this.reloadTimer = this.reloadTime;
+  }
+
+  update(dt, w, h, particles) {
+    super.update(dt, w, h);
+    this.reloadTimer = Math.max(0, this.reloadTimer - dt);
+  }
+
+  draw(ctx) {
+    const { x, y } = this;
+
+    // Aim line (dotted)
+    if (this.aimActive) {
+      ctx.save();
+      ctx.setLineDash([8, 8]);
+      ctx.strokeStyle = this.ready ? 'rgba(255, 200, 50, 0.6)' : 'rgba(150, 150, 150, 0.3)';
+      ctx.lineWidth = 3;
+      ctx.beginPath();
+      ctx.moveTo(x, y - 20);
+      const len = 200;
+      ctx.lineTo(x + Math.cos(this.aimAngle) * len, y - 20 + Math.sin(this.aimAngle) * len);
+      ctx.stroke();
+      ctx.setLineDash([]);
+      ctx.restore();
+    }
+
+    // Platform base
+    ctx.save();
+    ctx.translate(x, y);
+
+    // Metal platform
+    const grad = ctx.createLinearGradient(0, -12, 0, 12);
+    grad.addColorStop(0, '#888');
+    grad.addColorStop(0.5, '#aaa');
+    grad.addColorStop(1, '#666');
+    ctx.fillStyle = grad;
+
+    const hw = this.padWidth / 2;
+    const hh = this.padHeight / 2;
+    ctx.beginPath();
+    ctx.roundRect(-hw, -hh, this.padWidth, this.padHeight, 5);
+    ctx.fill();
+
+    // Side rails
+    ctx.fillStyle = '#555';
+    ctx.fillRect(-hw - 6, -hh - 8, 10, this.padHeight + 8);
+    ctx.fillRect(hw - 4, -hh - 8, 10, this.padHeight + 8);
+
+    // Rocket emoji on the pad (ready indicator)
+    if (this.ready) {
+      ctx.font = '36px serif';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      // Rotate to match aim direction. The 🚀 emoji faces ~-45° (upper-right)
+      ctx.save();
+      ctx.translate(0, -25);
+      ctx.rotate(this.aimAngle + Math.PI / 4);
+      ctx.fillText('🚀', 0, 0);
+      ctx.restore();
+    }
+
+    ctx.restore();
+  }
+}

--- a/src/actors/Rocket.js
+++ b/src/actors/Rocket.js
@@ -1,77 +1,57 @@
 import { Actor } from './Actor.js';
 
 export class Rocket extends Actor {
-  constructor(x, y) {
+  constructor(x, y, angle, speed) {
     super(x, y);
-    this.size = 75;
-    this.baseX = x;
-    this.bobTime = Math.random() * Math.PI * 2;
-    this.vy = -25;         // gentle upward drift
-    this.launched = false;
-    this.launchVY = 0;
+    this.size = 50;
+    this.vx = Math.cos(angle) * speed;
+    this.vy = Math.sin(angle) * speed;
+    this.angle = angle;
+    this.launched = true;
     this.trailTimer = 0;
-    // The 🚀 emoji faces upper-right (~45° from vertical).
-    // Rotate -45° so it points straight up by default.
-    this.rotationOffset = -Math.PI / 4;
+    this.lifetime = 5; // seconds before auto-remove
+    // The 🚀 emoji faces upper-right (~-45° or -π/4).
+    // To visually align with flight direction: rotate by (angle - (-π/4))
+    this.emojiOffset = Math.PI / 4;
   }
 
   update(dt, w, h, particles) {
     super.update(dt, w, h);
 
-    this.bobTime += dt * 0.7;
+    // Gravity pulls the rocket down
+    this.vy += 180 * dt;
+
+    // Update angle to match velocity direction
+    this.angle = Math.atan2(this.vy, this.vx);
+
+    this.x += this.vx * dt;
+    this.y += this.vy * dt;
+
+    // Trail particles from the back of the rocket
     this.trailTimer -= dt;
-
-    if (this.launched) {
-      this.launchVY += 120 * dt; // gravity
-      this.vy = this.launchVY;
-
-      // Emit trail from the bottom of the rocket
-      if (this.trailTimer <= 0) {
-        this.trailTimer = 0.03;
-        particles.trail(this.x, this.y + this.size * 0.5, '#FF6B00', { size: 12, life: 0.55, gravity: 30 });
-        particles.trail(this.x, this.y + this.size * 0.5, '#FFE44D', { size: 7,  life: 0.35, gravity: 20 });
-      }
-
-      // Return to cruise when past mid-screen
-      if (this.y > h * 0.45 && this.launchVY > 0) {
-        this.launched = false;
-        this.launchVY = 0;
-        this.vy = -25;
-      }
+    if (this.trailTimer <= 0) {
+      this.trailTimer = 0.025;
+      const backX = this.x - Math.cos(this.angle) * this.size * 0.4;
+      const backY = this.y - Math.sin(this.angle) * this.size * 0.4;
+      particles.trail(backX, backY, '#FF6B00', { size: 11, life: 0.5, gravity: 25 });
+      particles.trail(backX, backY, '#FFE44D', { size: 6, life: 0.3, gravity: 15 });
     }
 
-    this.y += this.vy * dt;
-    this.x = this.baseX + Math.sin(this.bobTime) * 22;
-
-    // Wrap vertically
-    if (this.y < -120) this.y = h + 120;
-    if (this.y > h + 120) this.y = -120;
+    // Remove if off-screen or lifetime expired
+    this.lifetime -= dt;
+    if (this.lifetime <= 0 || this.x < -150 || this.x > w + 150 || this.y < -150 || this.y > h + 150) {
+      this.alive = false;
+    }
   }
 
   draw(ctx) {
     ctx.save();
     ctx.translate(this.x, this.y);
-    ctx.rotate(this.rotationOffset);
+    ctx.rotate(this.angle + this.emojiOffset);
     ctx.font = `${this.size}px serif`;
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
     ctx.fillText('🚀', 0, 0);
     ctx.restore();
-  }
-
-  onTap(x, y, particles, audio) {
-    if (this.tapCooldown > 0) return;
-    this.tapCooldown = 2.2;
-
-    this.launched = true;
-    this.launchVY = -750;
-    this.vy = -750;
-
-    particles.burst(this.x, this.y + this.size * 0.5, 18, {
-      colors: ['#FF6B00', '#FFE44D', '#FF4444', '#FFA500'],
-      minSpeed: 90, maxSpeed: 220, gravity: 160,
-    });
-
-    audio.launch();
   }
 }

--- a/src/actors/Target.js
+++ b/src/actors/Target.js
@@ -12,9 +12,14 @@ export class Target extends Actor {
     this.baseY = y;
     this.scale = 0;        // pop-in animation
     this.scaleTarget = 1;
-    this.lifetime = 15 + Math.random() * 10; // seconds before fading away
+    this.lifetime = 15 + Math.random() * 10;
     this.fadeTimer = 0;
     this.hit = false;
+
+    // Horizontal drift — some move, some stay still
+    this.driftSpeed = (Math.random() > 0.3)
+      ? (30 + Math.random() * 60) * (Math.random() > 0.5 ? 1 : -1)
+      : 0;
   }
 
   update(dt, w, h, particles) {
@@ -22,6 +27,13 @@ export class Target extends Actor {
 
     // Pop-in animation
     this.scale += (this.scaleTarget - this.scale) * dt * 5;
+
+    // Horizontal drift
+    this.x += this.driftSpeed * dt;
+
+    // Wrap horizontally
+    if (this.x < -50) this.x = w + 50;
+    if (this.x > w + 50) this.x = -50;
 
     // Gentle bobbing
     this.bobTime += dt * 1.2;


### PR DESCRIPTION
## Summary
- **Launch pad** at the bottom center — metal platform with side rails and a ready-indicator rocket emoji
- **Tap-to-aim**: tap anywhere in the sky to launch a rocket from the pad toward that point
- **Aim line**: dotted golden line from pad to pointer while holding/dragging
- **Projectile rockets**: fly with gravity, rotate to match trajectory, leave fire trails, consumed on hit
- **Moving targets**: 70% of targets now drift horizontally across the sky with wrapping
- Reload cooldown (0.8s) between launches

## Test plan
- [ ] Launch pad visible at bottom center of screen
- [ ] Tap in the sky area → rocket launches from pad toward tap point
- [ ] Rocket follows arc trajectory (gravity), emoji rotates to match direction
- [ ] Fire trail emits from the back of the rocket
- [ ] Aim line appears while holding pointer
- [ ] Targets drift left/right across the screen
- [ ] Rocket + target collision → explosion + score
- [ ] Cannot launch downward (tapping below pad does nothing)
- [ ] Tapping other actors (cars, balls, stars) still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)