### PR TITLE
feat: car swerve and crash mechanics

### DIFF
--- a/src/AudioManager.js
+++ b/src/AudioManager.js
@@ -48,6 +48,20 @@ export class AudioManager {
     this._osc(50, 'sine', 0.15, 0.45, 350);
   }
 
+  carCrash() {
+    // Heavy metallic crash: low boom + mid crunch + high shatter
+    this._osc(40, 'sawtooth', 0.6, 0.5, 180);
+    this._osc(70, 'square', 0.4, 0.35, 300);
+    this._osc(200, 'sawtooth', 0.3, 0.2, 800);
+    setTimeout(() => {
+      this._osc(50, 'sine', 0.5, 0.3, 150);
+      this._osc(120, 'square', 0.25, 0.2, 400);
+    }, 100);
+    setTimeout(() => {
+      this._osc(30, 'sine', 0.4, 0.25);
+    }, 250);
+  }
+
   explosion() {
     // Satisfying hit sound: low boom + high sparkle
     this._osc(60, 'sine', 0.4, 0.45, 250);

--- a/src/World.js
+++ b/src/World.js
@@ -47,11 +47,13 @@ export class World {
     // Right-hand traffic: rightward cars in bottom lane, leftward in top lane
     const car1 = new Car(w * 0.15, h * 0.89);
     car1.laneY = 0.89;
+    car1.currentLaneY = 0.89;
     this.actors.push(car1);
 
     const car2 = new Car(w * 0.75, h * 0.78);
     car2.vx = -car2.baseSpeed;
     car2.laneY = 0.78;
+    car2.currentLaneY = 0.78;
     this.actors.push(car2);
 
     this.actors.push(new Ball(w * 0.28, h * 0.4));
@@ -207,6 +209,20 @@ export class World {
           rocket.alive = false; // rocket consumed on hit
           this.score += 1;
           this.scorePop = 1;
+        }
+      }
+    }
+
+    // ── Car ↔ Car collisions ──────────────────────────
+    const cars = this.actors.filter(a => a instanceof Car && !a.crashed);
+    for (let i = 0; i < cars.length; i++) {
+      for (let j = i + 1; j < cars.length; j++) {
+        const a = cars[i], b = cars[j];
+        // Only collide if one is swerving (on wrong lane)
+        if (!a.swerving && !b.swerving) continue;
+        const dist = Math.hypot(a.x - b.x, a.y - b.y);
+        if (dist < (a.size + b.size) * 0.45) {
+          a.triggerCrash(b, this.particles, this.audio);
         }
       }
     }

--- a/src/actors/Car.js
+++ b/src/actors/Car.js
@@ -15,10 +15,106 @@ export class Car extends Actor {
     this.boostTimer = 0;
     this.bounceY = 0;
     this.bounceVY = 0;
+
+    // Lane system
+    this.laneY = 0;       // home lane (fraction of h), set by World
+    this.currentLaneY = 0; // current target lane fraction
+    this.swerving = false;
+    this.swerveTimer = 0;
+
+    // Crash state
+    this.crashed = false;
+    this.crashSpin = 0;
+    this.crashVX = 0;
+    this.crashVY = 0;
+    this.crashAlpha = 1;
+    this.respawnTimer = 0;
+  }
+
+  get oppositeLaneY() {
+    // 0.89 ↔ 0.78
+    return this.laneY === 0.89 ? 0.78 : 0.89;
+  }
+
+  swerveToOncoming() {
+    if (this.swerving || this.crashed) return;
+    this.swerving = true;
+    this.currentLaneY = this.oppositeLaneY;
+    this.swerveTimer = 2.5 + Math.random() * 1.5; // time on wrong lane before returning
+  }
+
+  triggerCrash(otherCar, particles, audio) {
+    if (this.crashed) return;
+
+    const midX = (this.x + otherCar.x) / 2;
+    const midY = (this.y + otherCar.y) / 2;
+
+    // Mark both as crashed
+    this.crashed = true;
+    otherCar.crashed = true;
+
+    // Fling directions: cars fly apart
+    const pushDir = this.x < otherCar.x ? -1 : 1;
+    this.crashVX = pushDir * (200 + Math.random() * 150);
+    this.crashVY = -(250 + Math.random() * 200);
+    this.crashSpin = (3 + Math.random() * 5) * pushDir;
+
+    otherCar.crashVX = -pushDir * (200 + Math.random() * 150);
+    otherCar.crashVY = -(250 + Math.random() * 200);
+    otherCar.crashSpin = -(3 + Math.random() * 5) * pushDir;
+
+    this.respawnTimer = 3.5;
+    otherCar.respawnTimer = 3.5;
+
+    // Big explosion at collision point
+    particles.burst(midX, midY, 35, {
+      colors: ['#FF4400', '#FF8800', '#FFCC00', '#FF0000', '#FFE44D', '#333333'],
+      minSpeed: 120, maxSpeed: 450,
+      gravity: 200,
+      minSize: 6, maxSize: 20,
+    });
+
+    // Secondary debris burst
+    setTimeout(() => {
+      particles.burst(midX, midY, 20, {
+        colors: ['#666', '#999', '#FF6600', '#FFAA00'],
+        minSpeed: 50, maxSpeed: 200,
+        gravity: 300,
+        minSize: 3, maxSize: 10,
+      });
+    }, 150);
+
+    audio.carCrash();
   }
 
   update(dt, w, h) {
     super.update(dt, w, h);
+
+    if (this.crashed) {
+      // Fly away with spin
+      this.x += this.crashVX * dt;
+      this.crashVY += 400 * dt; // gravity
+      this.y += this.crashVY * dt;
+      this.crashAlpha = Math.max(0, this.crashAlpha - dt * 0.5);
+
+      this.respawnTimer -= dt;
+      if (this.respawnTimer <= 0) {
+        // Respawn: reset state
+        this.crashed = false;
+        this.crashAlpha = 1;
+        this.crashSpin = 0;
+        this.crashVX = 0;
+        this.crashVY = 0;
+        this.swerving = false;
+        this.currentLaneY = this.laneY;
+        this.y = h * this.laneY;
+        this.scale = 0; // pop-in animation
+        // Respawn off-screen
+        this.x = this.vx > 0 ? -100 : w + 100;
+        this.emoji = EMOJIS[Math.floor(Math.random() * EMOJIS.length)];
+      }
+      return;
+    }
 
     // Boost decay
     this.boostTimer = Math.max(0, this.boostTimer - dt);
@@ -38,6 +134,19 @@ export class Car extends Actor {
 
     this.x += this.vx * dt;
 
+    // Smooth lane transition
+    const targetY = h * this.currentLaneY;
+    this.y += (targetY - this.y) * Math.min(1, dt * 4);
+
+    // Swerve timer: return to home lane
+    if (this.swerving) {
+      this.swerveTimer -= dt;
+      if (this.swerveTimer <= 0) {
+        this.swerving = false;
+        this.currentLaneY = this.laneY;
+      }
+    }
+
     // Wrap horizontally
     if (this.vx > 0 && this.x > w + 120) this.x = -120;
     if (this.vx < 0 && this.x < -120) this.x = w + 120;
@@ -46,6 +155,12 @@ export class Car extends Actor {
   draw(ctx) {
     ctx.save();
     ctx.translate(this.x, this.y + this.bounceY);
+
+    if (this.crashed) {
+      ctx.globalAlpha = this.crashAlpha;
+      ctx.rotate(this.crashSpin * (1 - this.crashAlpha));
+    }
+
     if (this.vx > 0) ctx.scale(-1, 1);
     ctx.scale(this.scale, this.scale);
     if (this.colorFlash > 0) {
@@ -59,7 +174,7 @@ export class Car extends Actor {
   }
 
   onTap(x, y, particles, audio) {
-    if (this.tapCooldown > 0) return;
+    if (this.tapCooldown > 0 || this.crashed) return;
     this.tapCooldown = 0.4;
 
     this.vx = Math.sign(this.vx) * this.baseSpeed * 3.5;
@@ -75,5 +190,10 @@ export class Car extends Actor {
     });
 
     audio.honk();
+
+    // 30% chance to swerve to oncoming lane
+    if (Math.random() < 0.3) {
+      this.swerveToOncoming();
+    }
   }
 }


### PR DESCRIPTION
## Summary
- **30% swerve chance**: tapping a car can make it swerve to the oncoming lane
- **Smooth lane transition**: cars interpolate between lanes over time
- **Collision detection**: swerving cars that meet oncoming traffic trigger a crash
- **Crash effects**: 35-particle explosion + 20-particle debris burst, metallic crash sound (sawtooth + square oscillators)
- **Crash physics**: both cars spin and fly apart with gravity
- **Respawn**: crashed cars fade out, respawn off-screen after 3.5s with new random emoji

## Test plan
- [ ] Tap a car multiple times — eventually it swerves to the other lane
- [ ] Car smoothly moves to opposite lane when swerving
- [ ] If no collision, car returns to home lane after 2.5-4 seconds
- [ ] When swerving car meets oncoming car → big explosion + crash sound
- [ ] Both cars spin and fly off screen after crash
- [ ] Both cars respawn in their correct lanes after ~3.5 seconds
- [ ] Crashed cars cannot be tapped

🤖 Generated with [Claude Code](https://claude.com/claude-code)