### PR TITLE
fix: distinguish tap from drag to prevent input conflicts

### DIFF
--- a/src/InputManager.js
+++ b/src/InputManager.js
@@ -1,4 +1,8 @@
 export class InputManager {
+  // Thresholds for distinguishing taps from drags
+  static TAP_MAX_DISTANCE = 15;   // px — movement beyond this = drag
+  static TAP_MAX_DURATION = 200;  // ms — held longer than this = drag
+
   constructor(canvas) {
     this.canvas = canvas;
     this._taps = [];
@@ -6,6 +10,10 @@ export class InputManager {
     this.activeTouches = new Map();
     this.mouseDown = false;
     this.mousePos = null;
+
+    // Per-pointer tracking for tap vs drag classification
+    this._pointerStarts = new Map(); // id → { x, y, time }
+    this._drawingPointers = new Set(); // pointers confirmed as drawing
 
     this._exitHoldStart = null;
     this._exitTimer = null;
@@ -24,17 +32,20 @@ export class InputManager {
       const pos = this._mousePos(e);
       this.mouseDown = true;
       this.mousePos = pos;
+      this._pointerStarts.set('mouse', { x: pos.x, y: pos.y, time: Date.now() });
       this._onDown(pos);
     });
     c.addEventListener('mousemove', e => {
       e.preventDefault();
-      this.mousePos = this._mousePos(e);
+      const pos = this._mousePos(e);
+      this.mousePos = pos;
+      this._checkDragThreshold('mouse', pos);
     });
     c.addEventListener('mouseup', e => {
       e.preventDefault();
       const pos = this._mousePos(e);
       this.mouseDown = false;
-      this._onUp(pos);
+      this._onUp('mouse', pos);
     });
 
     // Touch
@@ -43,6 +54,7 @@ export class InputManager {
       for (const t of e.changedTouches) {
         const pos = this._touchPos(t);
         this.activeTouches.set(t.identifier, { ...pos, startTime: Date.now() });
+        this._pointerStarts.set(t.identifier, { x: pos.x, y: pos.y, time: Date.now() });
         this._onDown(pos);
       }
     }, { passive: false });
@@ -52,7 +64,9 @@ export class InputManager {
       for (const t of e.changedTouches) {
         if (this.activeTouches.has(t.identifier)) {
           const existing = this.activeTouches.get(t.identifier);
-          this.activeTouches.set(t.identifier, { ...this._touchPos(t), startTime: existing.startTime });
+          const pos = this._touchPos(t);
+          this.activeTouches.set(t.identifier, { ...pos, startTime: existing.startTime });
+          this._checkDragThreshold(t.identifier, pos);
         }
       }
     }, { passive: false });
@@ -62,13 +76,17 @@ export class InputManager {
       for (const t of e.changedTouches) {
         const pos = this._touchPos(t);
         this.activeTouches.delete(t.identifier);
-        this._onUp(pos);
+        this._onUp(t.identifier, pos);
       }
     }, { passive: false });
 
     c.addEventListener('touchcancel', e => {
       e.preventDefault();
-      for (const t of e.changedTouches) this.activeTouches.delete(t.identifier);
+      for (const t of e.changedTouches) {
+        this.activeTouches.delete(t.identifier);
+        this._pointerStarts.delete(t.identifier);
+        this._drawingPointers.delete(t.identifier);
+      }
       this._cancelExit();
     }, { passive: false });
 
@@ -113,8 +131,32 @@ export class InputManager {
     }
   }
 
-  _onUp(pos) {
-    this._taps.push(pos);
+  _checkDragThreshold(id, pos) {
+    const start = this._pointerStarts.get(id);
+    if (!start || this._drawingPointers.has(id)) return;
+    const dist = Math.hypot(pos.x - start.x, pos.y - start.y);
+    if (dist >= InputManager.TAP_MAX_DISTANCE) {
+      this._drawingPointers.add(id);
+    }
+  }
+
+  _onUp(id, pos) {
+    const start = this._pointerStarts.get(id);
+    const wasDrawing = this._drawingPointers.has(id);
+
+    // Clean up pointer tracking
+    this._pointerStarts.delete(id);
+    this._drawingPointers.delete(id);
+
+    // Classify: only emit a tap if the pointer stayed close and was brief
+    if (start && !wasDrawing) {
+      const dist = Math.hypot(pos.x - start.x, pos.y - start.y);
+      const duration = Date.now() - start.time;
+      if (dist < InputManager.TAP_MAX_DISTANCE && duration < InputManager.TAP_MAX_DURATION) {
+        this._taps.push(pos);
+      }
+    }
+
     if (this._exitHoldStart !== null) {
       this._exitHoldStart = null;
       this._cancelExit();
@@ -158,6 +200,11 @@ export class InputManager {
     const keys = this._keys;
     this._keys = [];
     return keys;
+  }
+
+  // Returns true if a pointer has exceeded the drag threshold
+  isDrawing(id) {
+    return this._drawingPointers.has(id);
   }
 
   // Returns [{id, x, y}] for all currently held pointers

--- a/src/World.js
+++ b/src/World.js
@@ -153,10 +153,14 @@ export class World {
       }
     }
 
-    // ── Drawing ───────────────────────────────────────────
+    // ── Drawing (only for pointers that exceeded the drag threshold) ──
     const currentIds = new Set(pointers.map(p => p.id));
+    const drawingIds = new Set();
 
     for (const p of pointers) {
+      if (!this.input.isDrawing(p.id)) continue; // not dragging yet — skip
+
+      drawingIds.add(p.id);
       if (!this._prevPointerIds.has(p.id)) {
         this.drawing.startStroke(p.id, p.x, p.y);
       } else {
@@ -164,9 +168,9 @@ export class World {
       }
     }
     for (const id of this._prevPointerIds) {
-      if (!currentIds.has(id)) this.drawing.endStroke(id);
+      if (!drawingIds.has(id)) this.drawing.endStroke(id);
     }
-    this._prevPointerIds = currentIds;
+    this._prevPointerIds = drawingIds;
 
     this.drawing.update(dt);
 


### PR DESCRIPTION
## Summary
- Add distance (15px) and time (200ms) thresholds to classify pointer interactions as taps vs drags
- Drawing mode only activates after pointer movement exceeds the drag threshold
- Short taps still work for all actor interactions (cars, balls, stars, butterflies) and rocket launches

Closes #9

## Test plan
- [ ] Tap on actors (cars, balls, stars, butterflies) — should trigger interaction without starting a drawing stroke
- [ ] Tap on empty space — should launch a rocket without starting a drawing stroke
- [ ] Press and drag across the screen — should draw a rainbow trail without launching a rocket
- [ ] Short drags (< 15px) should be treated as taps, not drawing
- [ ] Long press without movement (> 200ms) should not trigger a tap on release
- [ ] Multi-touch drawing still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)