### PR TITLE
feat: replace numeric score with visual star progress bar

### DIFF
--- a/src/World.js
+++ b/src/World.js
@@ -28,9 +28,6 @@ export class World {
 
     this.emergentTimer = 6 + Math.random() * 10;
     this.targetTimer = 3;
-    this.score = 0;
-    this.scoreDisplay = 0;
-    this.scorePop = 0;
 
     this.goals = new GoalManager();
     this.launchPad = null;
@@ -211,8 +208,6 @@ export class World {
         if (dist < (rocket.size + target.size) * 0.45) {
           target.explode(this.particles, this.audio);
           rocket.alive = false; // rocket consumed on hit
-          this.score += 1;
-          this.scorePop = 1;
           const goalDone = this.goals.recordHit();
           if (goalDone) {
             this.goals.triggerCelebration(this.particles, this.audio, this.w, this.h);
@@ -248,10 +243,6 @@ export class World {
 
     // ── Goal tracking ─────────────────────────────────
     this.goals.update(dt);
-
-    // ── Score animation ─────────────────────────────────
-    this.scoreDisplay += (this.score - this.scoreDisplay) * dt * 8;
-    this.scorePop = Math.max(0, this.scorePop - dt * 3);
 
     // ── Emergent events ───────────────────────────────────
     this.emergentTimer -= dt;


### PR DESCRIPTION
## Summary
- Removed leftover numeric score tracking (`score`, `scoreDisplay`, `scorePop`) from `World.js`
- The `GoalManager` already provides a purely visual star progress bar with animated pop-in fills and celebration effects
- No numbers are visible anywhere -- progress is shown entirely through filled/empty stars

Closes #13

## Test plan
- [ ] Verify star progress bar displays at top of screen
- [ ] Hit targets with rockets and confirm stars fill with pop animation
- [ ] Complete a goal and verify celebration triggers, then stars reset for next level
- [ ] Confirm no numeric score is displayed anywhere on screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)