### PR TITLE
feat: add themed rooms with swipe navigation

### DIFF
--- a/src/Background.js
+++ b/src/Background.js
@@ -48,6 +48,40 @@ export class Background {
       phase: Math.random() * Math.PI * 2,
       speed: 1.5 + Math.random() * 3,
     }));
+
+    // Space scene: many dense stars
+    this.spaceStars = Array.from({ length: 200 }, () => ({
+      x: Math.random(),
+      y: Math.random(),
+      r: 0.5 + Math.random() * 3,
+      phase: Math.random() * Math.PI * 2,
+      speed: 1 + Math.random() * 4,
+    }));
+
+    // Space scene: planets
+    this.planets = [
+      { x: 0.15, y: 0.25, emoji: '🪐', size: 70 },
+      { x: 0.82, y: 0.18, emoji: '🌍', size: 55 },
+      { x: 0.55, y: 0.08, emoji: '🌙', size: 45 },
+    ];
+
+    // Underwater scene: bubbles
+    this.bubbles = Array.from({ length: 30 }, () => ({
+      x: Math.random(),
+      y: Math.random(),
+      r: 3 + Math.random() * 10,
+      speed: 0.02 + Math.random() * 0.04,
+      wobblePhase: Math.random() * Math.PI * 2,
+      wobbleSpeed: 1.5 + Math.random() * 2,
+    }));
+
+    // Underwater scene: seaweed positions
+    this.seaweeds = Array.from({ length: 8 }, () => ({
+      x: 0.05 + Math.random() * 0.9,
+      height: 0.08 + Math.random() * 0.12,
+      phase: Math.random() * Math.PI * 2,
+      speed: 1 + Math.random() * 1.5,
+    }));
   }
 
   update(dt) {
@@ -58,6 +92,20 @@ export class Background {
     }
     for (const s of this.stars) {
       s.phase += s.speed * dt;
+    }
+    for (const s of this.spaceStars) {
+      s.phase += s.speed * dt;
+    }
+    for (const b of this.bubbles) {
+      b.y -= b.speed * dt;
+      b.wobblePhase += b.wobbleSpeed * dt;
+      if (b.y < -0.05) {
+        b.y = 1.05;
+        b.x = Math.random();
+      }
+    }
+    for (const sw of this.seaweeds) {
+      sw.phase += sw.speed * dt;
     }
   }
 
@@ -143,7 +191,8 @@ export class Background {
     ctx.setLineDash([]);
   }
 
-  draw(ctx, w, h) {
+  /** Draw the road scene (original). */
+  drawRoad(ctx, w, h) {
     const horizonY = h * 0.70;
     const skyC = sampleStops(SKY_STOPS, this.time);
     const gndC = sampleStops(GROUND_STOPS, this.time);
@@ -191,5 +240,144 @@ export class Background {
 
     // Road
     this._drawRoad(ctx, w, h, horizonY);
+  }
+
+  /** Draw the space scene. */
+  drawSpace(ctx, w, h) {
+    // Deep space background gradient
+    const grad = ctx.createLinearGradient(0, 0, 0, h);
+    grad.addColorStop(0, '#0a0020');
+    grad.addColorStop(0.5, '#0d0040');
+    grad.addColorStop(1, '#150060');
+    ctx.fillStyle = grad;
+    ctx.fillRect(0, 0, w, h);
+
+    // Dense starfield
+    ctx.fillStyle = '#ffffff';
+    for (const s of this.spaceStars) {
+      ctx.globalAlpha = 0.3 + 0.7 * Math.abs(Math.sin(s.phase));
+      ctx.beginPath();
+      ctx.arc(s.x * w, s.y * h, s.r, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    ctx.globalAlpha = 1;
+
+    // Nebula glow patches
+    ctx.save();
+    ctx.globalAlpha = 0.08;
+    const glow1 = ctx.createRadialGradient(w * 0.3, h * 0.4, 0, w * 0.3, h * 0.4, w * 0.3);
+    glow1.addColorStop(0, '#8B00FF');
+    glow1.addColorStop(1, 'transparent');
+    ctx.fillStyle = glow1;
+    ctx.fillRect(0, 0, w, h);
+
+    const glow2 = ctx.createRadialGradient(w * 0.7, h * 0.6, 0, w * 0.7, h * 0.6, w * 0.25);
+    glow2.addColorStop(0, '#00BFFF');
+    glow2.addColorStop(1, 'transparent');
+    ctx.fillStyle = glow2;
+    ctx.fillRect(0, 0, w, h);
+    ctx.restore();
+
+    // Planets (background decoration)
+    for (const p of this.planets) {
+      ctx.font = `${p.size}px serif`;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(p.emoji, p.x * w, p.y * h);
+    }
+  }
+
+  /** Draw the underwater scene. */
+  drawUnderwater(ctx, w, h) {
+    // Blue-green water gradient
+    const grad = ctx.createLinearGradient(0, 0, 0, h);
+    grad.addColorStop(0, '#006994');
+    grad.addColorStop(0.3, '#005577');
+    grad.addColorStop(0.7, '#003B4D');
+    grad.addColorStop(1, '#002233');
+    ctx.fillStyle = grad;
+    ctx.fillRect(0, 0, w, h);
+
+    // Light rays from surface
+    ctx.save();
+    ctx.globalAlpha = 0.06;
+    for (let i = 0; i < 5; i++) {
+      const x = w * (0.1 + i * 0.2);
+      ctx.beginPath();
+      ctx.moveTo(x - 20, 0);
+      ctx.lineTo(x + 30, 0);
+      ctx.lineTo(x + 80 + i * 15, h);
+      ctx.lineTo(x - 60 + i * 10, h);
+      ctx.closePath();
+      ctx.fillStyle = '#4FC3F7';
+      ctx.fill();
+    }
+    ctx.restore();
+
+    // Seaweed at bottom
+    ctx.save();
+    for (const sw of this.seaweeds) {
+      const baseX = sw.x * w;
+      const baseY = h;
+      const topY = h - sw.height * h;
+      const sway = Math.sin(sw.phase) * 15;
+
+      ctx.strokeStyle = '#2E7D32';
+      ctx.lineWidth = 6;
+      ctx.lineCap = 'round';
+      ctx.beginPath();
+      ctx.moveTo(baseX, baseY);
+      ctx.quadraticCurveTo(baseX + sway, (baseY + topY) / 2, baseX + sway * 1.5, topY);
+      ctx.stroke();
+
+      ctx.strokeStyle = '#388E3C';
+      ctx.lineWidth = 4;
+      ctx.beginPath();
+      ctx.moveTo(baseX + 8, baseY);
+      ctx.quadraticCurveTo(baseX + 8 - sway * 0.8, (baseY + topY + 20) / 2, baseX + 8 - sway, topY + 20);
+      ctx.stroke();
+    }
+    ctx.restore();
+
+    // Sandy bottom
+    const sandGrad = ctx.createLinearGradient(0, h - 40, 0, h);
+    sandGrad.addColorStop(0, 'rgba(194, 178, 128, 0)');
+    sandGrad.addColorStop(0.5, 'rgba(194, 178, 128, 0.3)');
+    sandGrad.addColorStop(1, 'rgba(194, 178, 128, 0.5)');
+    ctx.fillStyle = sandGrad;
+    ctx.fillRect(0, h - 40, w, 40);
+
+    // Bubbles
+    ctx.save();
+    for (const b of this.bubbles) {
+      const bx = b.x * w + Math.sin(b.wobblePhase) * 8;
+      const by = b.y * h;
+      ctx.globalAlpha = 0.3;
+      ctx.strokeStyle = '#B3E5FC';
+      ctx.lineWidth = 1.5;
+      ctx.beginPath();
+      ctx.arc(bx, by, b.r, 0, Math.PI * 2);
+      ctx.stroke();
+
+      // Shine highlight
+      ctx.globalAlpha = 0.15;
+      ctx.fillStyle = '#FFFFFF';
+      ctx.beginPath();
+      ctx.arc(bx - b.r * 0.3, by - b.r * 0.3, b.r * 0.25, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    ctx.globalAlpha = 1;
+    ctx.restore();
+  }
+
+  /** Main draw dispatcher based on scene ID. */
+  draw(ctx, w, h, sceneId) {
+    if (sceneId === 'space') {
+      this.drawSpace(ctx, w, h);
+    } else if (sceneId === 'underwater') {
+      this.drawUnderwater(ctx, w, h);
+    } else {
+      this.drawRoad(ctx, w, h);
+    }
   }
 }

--- a/src/InputManager.js
+++ b/src/InputManager.js
@@ -7,6 +7,10 @@ export class InputManager {
     this.mouseDown = false;
     this.mousePos = null;
 
+    // Swipe event queue for SceneManager
+    this._swipeEvents = [];
+    this._mouseDownPos = null;
+
     this._exitHoldStart = null;
     this._exitTimer = null;
     this._exitOverlay = document.getElementById('exit-overlay');
@@ -24,25 +28,35 @@ export class InputManager {
       const pos = this._mousePos(e);
       this.mouseDown = true;
       this.mousePos = pos;
+      this._mouseDownPos = { ...pos };
+      this._swipeEvents.push({ type: 'down', ...pos });
       this._onDown(pos);
     });
     c.addEventListener('mousemove', e => {
       e.preventDefault();
       this.mousePos = this._mousePos(e);
+      if (this.mouseDown) {
+        this._swipeEvents.push({ type: 'move', ...this.mousePos });
+      }
     });
     c.addEventListener('mouseup', e => {
       e.preventDefault();
       const pos = this._mousePos(e);
       this.mouseDown = false;
+      this._swipeEvents.push({ type: 'up', ...pos });
       this._onUp(pos);
     });
 
-    // Touch
+    // Touch — only track the first touch for swipe detection
     c.addEventListener('touchstart', e => {
       e.preventDefault();
       for (const t of e.changedTouches) {
         const pos = this._touchPos(t);
         this.activeTouches.set(t.identifier, { ...pos, startTime: Date.now() });
+        // Use first touch for swipe detection
+        if (e.touches.length === 1) {
+          this._swipeEvents.push({ type: 'down', ...pos });
+        }
         this._onDown(pos);
       }
     }, { passive: false });
@@ -52,7 +66,12 @@ export class InputManager {
       for (const t of e.changedTouches) {
         if (this.activeTouches.has(t.identifier)) {
           const existing = this.activeTouches.get(t.identifier);
-          this.activeTouches.set(t.identifier, { ...this._touchPos(t), startTime: existing.startTime });
+          const pos = this._touchPos(t);
+          this.activeTouches.set(t.identifier, { ...pos, startTime: existing.startTime });
+          // Track first touch for swipe
+          if (t.identifier === e.touches[0]?.identifier) {
+            this._swipeEvents.push({ type: 'move', ...pos });
+          }
         }
       }
     }, { passive: false });
@@ -61,6 +80,7 @@ export class InputManager {
       e.preventDefault();
       for (const t of e.changedTouches) {
         const pos = this._touchPos(t);
+        this._swipeEvents.push({ type: 'up', ...pos });
         this.activeTouches.delete(t.identifier);
         this._onUp(pos);
       }
@@ -146,6 +166,12 @@ export class InputManager {
       this._exitTimer = null;
     }
     this._exitOverlay.classList.remove('visible');
+  }
+
+  consumeSwipeEvents() {
+    const events = this._swipeEvents;
+    this._swipeEvents = [];
+    return events;
   }
 
   consumeTaps() {

--- a/src/SceneManager.js
+++ b/src/SceneManager.js
@@ -1,0 +1,173 @@
+/**
+ * SceneManager handles multiple themed scenes with swipe navigation.
+ * It detects horizontal swipes (distinguished from drawing) and animates
+ * smooth transitions between scenes.
+ */
+
+export const SCENE_ROAD = 0;
+export const SCENE_SPACE = 1;
+export const SCENE_UNDERWATER = 2;
+
+export const SCENE_CONFIGS = [
+  {
+    id: 'road',
+    name: 'Road',
+  },
+  {
+    id: 'space',
+    name: 'Space',
+  },
+  {
+    id: 'underwater',
+    name: 'Underwater',
+  },
+];
+
+export class SceneManager {
+  constructor() {
+    this.currentIndex = 0;
+    this.sceneCount = SCENE_CONFIGS.length;
+
+    // Transition animation
+    this.slideOffset = 0;   // -1 to 1 range during transition, 0 = settled
+    this.transitioning = false;
+    this.transitionSpeed = 4; // how fast the slide animates (higher = faster)
+
+    // Swipe detection state
+    this._swipeStartX = null;
+    this._swipeStartY = null;
+    this._swipeStartTime = null;
+    this._swipeTriggered = false;
+
+    // Thresholds
+    this._minSwipeDist = 100;    // px horizontal
+    this._maxSwipeTime = 500;    // ms
+    this._maxVerticalDrift = 80; // px - if vertical movement exceeds this, it's drawing not swiping
+
+    // Dot indicator animation
+    this._dotPulse = 0;
+  }
+
+  /**
+   * Called when a pointer/touch goes down.
+   * Returns false so InputManager can still process normally.
+   */
+  onPointerDown(x, y) {
+    if (this.transitioning) return;
+    this._swipeStartX = x;
+    this._swipeStartY = y;
+    this._swipeStartTime = Date.now();
+    this._swipeTriggered = false;
+  }
+
+  /**
+   * Called when a pointer/touch moves.
+   * Returns true if this looks like a swipe (caller should suppress drawing).
+   */
+  onPointerMove(x, y) {
+    if (this.transitioning || this._swipeStartX === null) return false;
+
+    const dx = x - this._swipeStartX;
+    const dy = y - this._swipeStartY;
+
+    // If vertical drift is too large, it's drawing, not a swipe
+    if (Math.abs(dy) > this._maxVerticalDrift) {
+      this._swipeStartX = null;
+      return false;
+    }
+
+    return Math.abs(dx) > 30; // mild horizontal movement hint
+  }
+
+  /**
+   * Called when a pointer/touch goes up.
+   * Returns true if a swipe was detected and consumed.
+   */
+  onPointerUp(x, y) {
+    if (this.transitioning || this._swipeStartX === null) {
+      this._swipeStartX = null;
+      return false;
+    }
+
+    const dx = x - this._swipeStartX;
+    const dy = y - this._swipeStartY;
+    const elapsed = Date.now() - this._swipeStartTime;
+
+    this._swipeStartX = null;
+
+    // Check swipe criteria: fast enough, horizontal enough
+    if (Math.abs(dx) >= this._minSwipeDist &&
+        elapsed <= this._maxSwipeTime &&
+        Math.abs(dy) < this._maxVerticalDrift) {
+
+      if (dx < 0 && this.currentIndex < this.sceneCount - 1) {
+        // Swipe left → go to next scene
+        this._startTransition(1);
+        return true;
+      } else if (dx > 0 && this.currentIndex > 0) {
+        // Swipe right → go to previous scene
+        this._startTransition(-1);
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  _startTransition(direction) {
+    this.transitioning = true;
+    // direction: 1 = going forward (slide from right), -1 = going back (slide from left)
+    this.slideOffset = direction; // start with next scene off-screen
+    this.currentIndex += direction;
+  }
+
+  update(dt) {
+    this._dotPulse += dt * 3;
+
+    if (!this.transitioning) return;
+
+    // Animate slide offset towards 0
+    const speed = this.transitionSpeed * dt;
+    if (Math.abs(this.slideOffset) < speed) {
+      this.slideOffset = 0;
+      this.transitioning = false;
+    } else {
+      this.slideOffset -= Math.sign(this.slideOffset) * speed;
+    }
+  }
+
+  /** Draw dot indicators at bottom center. */
+  drawIndicators(ctx, w, h) {
+    const dotRadius = 7;
+    const gap = 24;
+    const totalWidth = (this.sceneCount - 1) * gap;
+    const startX = (w - totalWidth) / 2;
+    const y = h - 30;
+
+    ctx.save();
+    for (let i = 0; i < this.sceneCount; i++) {
+      const x = startX + i * gap;
+      const isCurrent = i === this.currentIndex;
+
+      ctx.beginPath();
+      const r = isCurrent ? dotRadius + 1.5 * Math.sin(this._dotPulse) * 0.3 + 1 : dotRadius;
+      ctx.arc(x, y, r, 0, Math.PI * 2);
+
+      if (isCurrent) {
+        ctx.fillStyle = 'rgba(255, 255, 255, 0.95)';
+        ctx.shadowColor = 'rgba(255, 255, 255, 0.6)';
+        ctx.shadowBlur = 10;
+      } else {
+        ctx.fillStyle = 'rgba(255, 255, 255, 0.35)';
+        ctx.shadowBlur = 0;
+      }
+      ctx.fill();
+    }
+    ctx.shadowBlur = 0;
+    ctx.restore();
+  }
+
+  get currentScene() {
+    return SCENE_CONFIGS[this.currentIndex];
+  }
+}

--- a/src/World.js
+++ b/src/World.js
@@ -9,7 +9,10 @@ import { Star } from './actors/Star.js';
 import { Butterfly } from './actors/Butterfly.js';
 import { Target } from './actors/Target.js';
 import { LaunchPad } from './actors/LaunchPad.js';
+import { Fish } from './actors/Fish.js';
+import { Astronaut } from './actors/Astronaut.js';
 import { GoalManager } from './GoalManager.js';
+import { SceneManager, SCENE_CONFIGS } from './SceneManager.js';
 
 export class World {
   constructor(canvas, ctx, input, audio) {
@@ -22,7 +25,12 @@ export class World {
     this.particles = new ParticleSystem();
     this.drawing = new DrawingLayer();
     this.keyLabels = [];
-    this.actors = [];
+
+    // Per-scene actor storage
+    this.sceneActors = SCENE_CONFIGS.map(() => []);
+    this.sceneLaunchPads = SCENE_CONFIGS.map(() => null);
+
+    this.sceneManager = new SceneManager();
 
     this._prevPointerIds = new Set();
 
@@ -33,53 +41,141 @@ export class World {
     this.scorePop = 0;
 
     this.goals = new GoalManager();
-    this.launchPad = null;
     this._prevW = this.w;
     this._prevH = this.h;
 
-    this._spawn();
+    // Spawn actors for all scenes
+    this._spawnRoad();
+    this._spawnSpace();
+    this._spawnUnderwater();
   }
 
   get w() { return this.canvas.width; }
   get h() { return this.canvas.height; }
 
-  _spawn() {
-    const { w, h } = this;
+  // Convenience accessors for current scene
+  get actors() { return this.sceneActors[this.sceneManager.currentIndex]; }
+  set actors(v) { this.sceneActors[this.sceneManager.currentIndex] = v; }
+  get launchPad() { return this.sceneLaunchPads[this.sceneManager.currentIndex]; }
 
-    // Right-hand traffic: rightward cars in bottom lane, leftward in top lane
+  _spawnRoad() {
+    const { w, h } = this;
+    const actors = this.sceneActors[0];
+
     const car1 = new Car(w * 0.15, h * 0.89);
     car1.laneY = 0.89;
     car1.currentLaneY = 0.89;
-    this.actors.push(car1);
+    actors.push(car1);
 
     const car2 = new Car(w * 0.75, h * 0.78);
     car2.vx = -car2.baseSpeed;
     car2.laneY = 0.78;
     car2.currentLaneY = 0.78;
-    this.actors.push(car2);
+    actors.push(car2);
 
-    this.actors.push(new Ball(w * 0.28, h * 0.4));
-    this.actors.push(new Ball(w * 0.72, h * 0.32));
+    actors.push(new Ball(w * 0.28, h * 0.4));
+    actors.push(new Ball(w * 0.72, h * 0.32));
 
-    // Launch pad at bottom center, above the road
-    this.launchPad = new LaunchPad(w * 0.5, h * 0.72);
-    this.actors.push(this.launchPad);
+    const pad = new LaunchPad(w * 0.5, h * 0.72);
+    this.sceneLaunchPads[0] = pad;
+    actors.push(pad);
 
     for (let i = 0; i < 3; i++) {
-      this.actors.push(new Star(w * (0.18 + i * 0.32), h * (0.12 + Math.random() * 0.2)));
+      actors.push(new Star(w * (0.18 + i * 0.32), h * (0.12 + Math.random() * 0.2)));
     }
 
     for (let i = 0; i < 2; i++) {
       const b = new Butterfly(w * (0.25 + i * 0.5), h * 0.35);
       b._pickNewTarget();
-      this.actors.push(b);
+      actors.push(b);
     }
 
-    // Initial targets
     for (let i = 0; i < 3; i++) {
       const tx = w * (0.15 + i * 0.35);
       const ty = h * (0.08 + Math.random() * 0.25);
-      this.actors.push(new Target(tx, ty));
+      actors.push(new Target(tx, ty));
+    }
+  }
+
+  _spawnSpace() {
+    const { w, h } = this;
+    const actors = this.sceneActors[1];
+
+    // Floating astronauts and space objects
+    for (let i = 0; i < 4; i++) {
+      const a = new Astronaut(w * (0.15 + i * 0.25), h * (0.15 + Math.random() * 0.5));
+      a._pickNewTarget();
+      actors.push(a);
+    }
+
+    // Balls floating in zero-g
+    const b1 = new Ball(w * 0.3, h * 0.5);
+    b1.gravity = 30; // very low gravity in space
+    b1.bounciness = 0.9;
+    actors.push(b1);
+
+    const b2 = new Ball(w * 0.7, h * 0.4);
+    b2.gravity = 30;
+    b2.bounciness = 0.9;
+    actors.push(b2);
+
+    // Stars
+    for (let i = 0; i < 3; i++) {
+      actors.push(new Star(w * (0.15 + i * 0.35), h * (0.1 + Math.random() * 0.3)));
+    }
+
+    // Launch pad
+    const pad = new LaunchPad(w * 0.5, h * 0.85);
+    this.sceneLaunchPads[1] = pad;
+    actors.push(pad);
+
+    // Targets
+    for (let i = 0; i < 3; i++) {
+      const tx = w * (0.15 + i * 0.35);
+      const ty = h * (0.08 + Math.random() * 0.3);
+      actors.push(new Target(tx, ty));
+    }
+  }
+
+  _spawnUnderwater() {
+    const { w, h } = this;
+    const actors = this.sceneActors[2];
+
+    // Fish swimming around
+    for (let i = 0; i < 5; i++) {
+      const f = new Fish(w * (0.1 + i * 0.2), h * (0.15 + Math.random() * 0.6));
+      f._pickNewTarget();
+      actors.push(f);
+    }
+
+    // A big whale/shark
+    const whale = new Fish(w * 0.5, h * 0.7);
+    whale.emoji = '🦈';
+    whale.size = 80;
+    whale._pickNewTarget();
+    actors.push(whale);
+
+    // Balls (floating underwater)
+    const b1 = new Ball(w * 0.35, h * 0.3);
+    b1.gravity = 50; // slower sinking
+    b1.bounciness = 0.75;
+    actors.push(b1);
+
+    // Stars (as collectibles)
+    for (let i = 0; i < 2; i++) {
+      actors.push(new Star(w * (0.25 + i * 0.5), h * (0.1 + Math.random() * 0.25)));
+    }
+
+    // Launch pad at bottom
+    const pad = new LaunchPad(w * 0.5, h * 0.88);
+    this.sceneLaunchPads[2] = pad;
+    actors.push(pad);
+
+    // Targets
+    for (let i = 0; i < 3; i++) {
+      const tx = w * (0.15 + i * 0.35);
+      const ty = h * (0.08 + Math.random() * 0.3);
+      actors.push(new Target(tx, ty));
     }
   }
 
@@ -88,10 +184,9 @@ export class World {
     if (!pad || !pad.ready) return;
 
     const startX = pad.x;
-    const startY = pad.y - 25; // launch from top of pad
+    const startY = pad.y - 25;
     const angle = Math.atan2(tapY - startY, tapX - startX);
 
-    // Don't launch downward — only allow angles pointing upward
     if (angle >= 0) return;
 
     const speed = 650;
@@ -99,7 +194,6 @@ export class World {
     this.actors.push(rocket);
     pad.launch();
 
-    // Launch burst
     this.particles.burst(startX, startY, 14, {
       colors: ['#FF6B00', '#FFE44D', '#FF4444', '#FFA500'],
       minSpeed: 60, maxSpeed: 180, gravity: 160,
@@ -118,14 +212,27 @@ export class World {
 
     this.bg.update(dt);
     this.audio.music.update(dt, this.bg.time);
+    this.sceneManager.update(dt);
 
     // ── Pointer tracking for aim line ──────────────────
     const pointers = this.input.getActivePointers();
     if (pointers.length > 0 && this.launchPad) {
-      // Use the first pointer for aiming
       this.launchPad.setAim(pointers[0].x, pointers[0].y);
     } else if (this.launchPad) {
       this.launchPad.clearAim();
+    }
+
+    // ── Swipe detection for scene changes ──────────────
+    // Feed pointer events to scene manager
+    const swipeEvents = this.input.consumeSwipeEvents();
+    for (const evt of swipeEvents) {
+      if (evt.type === 'down') {
+        this.sceneManager.onPointerDown(evt.x, evt.y);
+      } else if (evt.type === 'move') {
+        this.sceneManager.onPointerMove(evt.x, evt.y);
+      } else if (evt.type === 'up') {
+        this.sceneManager.onPointerUp(evt.x, evt.y);
+      }
     }
 
     // ── Taps ─────────────────────────────────────────────
@@ -133,10 +240,12 @@ export class World {
     if (taps.length > 0) this.audio.unlock();
 
     for (const tap of taps) {
+      // Don't process taps during transition
+      if (this.sceneManager.transitioning) continue;
+
       let hit = false;
       for (let i = this.actors.length - 1; i >= 0; i--) {
         const actor = this.actors[i];
-        // Skip launch pad and rockets for hit testing — they don't consume taps
         if (actor instanceof LaunchPad || actor instanceof Rocket) continue;
         if (actor.hitTest(tap.x, tap.y)) {
           actor.onTap(tap.x, tap.y, this.particles, this.audio);
@@ -145,10 +254,8 @@ export class World {
         }
       }
 
-      // Any tap that doesn't hit another actor → launch a rocket toward that point
       if (!hit) {
         this._launchRocket(tap.x, tap.y);
-        // Also show particles at tap point
         this.particles.burst(tap.x, tap.y, 8, {
           colors: ['#FFD700', '#FF6B6B', '#4ECDC4', '#FF9FF3', '#A8E6CF'],
           minSpeed: 25, maxSpeed: 80, gravity: 120,
@@ -197,12 +304,14 @@ export class World {
     this.keyLabels = this.keyLabels.filter(l => l.alive);
     for (const l of this.keyLabels) l.update(dt);
 
-    // ── Actors ────────────────────────────────────────────
-    for (const actor of this.actors) {
-      actor.update(dt, this.w, this.h, this.particles);
+    // ── Update actors for ALL scenes (so they stay alive) ──
+    for (let s = 0; s < this.sceneActors.length; s++) {
+      for (const actor of this.sceneActors[s]) {
+        actor.update(dt, this.w, this.h, this.particles);
+      }
     }
 
-    // ── Rocket ↔ Target collisions ──────────────────────
+    // ── Rocket ↔ Target collisions (current scene only) ──
     const rockets = this.actors.filter(a => a instanceof Rocket && a.launched);
     const targets = this.actors.filter(a => a instanceof Target && !a.hit);
     for (const rocket of rockets) {
@@ -210,7 +319,7 @@ export class World {
         const dist = Math.hypot(rocket.x - target.x, rocket.y - target.y);
         if (dist < (rocket.size + target.size) * 0.45) {
           target.explode(this.particles, this.audio);
-          rocket.alive = false; // rocket consumed on hit
+          rocket.alive = false;
           this.score += 1;
           this.scorePop = 1;
           const goalDone = this.goals.recordHit();
@@ -221,12 +330,12 @@ export class World {
       }
     }
 
-    // ── Car ↔ Car collisions ──────────────────────────
-    const cars = this.actors.filter(a => a instanceof Car && !a.crashed);
+    // ── Car ↔ Car collisions (road scene only) ──────────
+    const roadActors = this.sceneActors[0];
+    const cars = roadActors.filter(a => a instanceof Car && !a.crashed);
     for (let i = 0; i < cars.length; i++) {
       for (let j = i + 1; j < cars.length; j++) {
         const a = cars[i], b = cars[j];
-        // Only collide if one is swerving (on wrong lane)
         if (!a.swerving && !b.swerving) continue;
         const dist = Math.hypot(a.x - b.x, a.y - b.y);
         if (dist < (a.size + b.size) * 0.45) {
@@ -235,11 +344,14 @@ export class World {
       }
     }
 
-    this.actors = this.actors.filter(a => a.alive);
+    // ── Clean up dead actors in all scenes ──────────────
+    for (let s = 0; s < this.sceneActors.length; s++) {
+      this.sceneActors[s] = this.sceneActors[s].filter(a => a.alive);
+    }
 
     this.particles.update(dt);
 
-    // ── Target spawning ─────────────────────────────────
+    // ── Target spawning (current scene) ─────────────────
     this.targetTimer -= dt;
     if (this.targetTimer <= 0) {
       this._spawnTarget();
@@ -265,44 +377,40 @@ export class World {
     const sx = newW / oldW;
     const sy = newH / oldH;
 
-    for (const actor of this.actors) {
-      if (actor instanceof LaunchPad) {
-        // Fixed position: always bottom center
-        actor.x = newW * 0.5;
-        actor.y = newH * 0.72;
-      } else if (actor instanceof Car) {
-        // Cars stay in their lane, scale x proportionally
-        actor.x *= sx;
-        actor.y = newH * (actor.laneY || 0.82);
-      } else if (actor instanceof Ball) {
-        // Scale position, keep within bounds
-        actor.x *= sx;
-        actor.y *= sy;
-      } else if (actor instanceof Star) {
-        // Scale base positions (actual position derived from base + bob)
-        actor.baseX *= sx;
-        actor.baseY *= sy;
-        actor.x = actor.baseX;
-        actor.y = actor.baseY;
-      } else if (actor instanceof Target) {
-        // Scale positions
-        actor.x *= sx;
-        actor.baseY *= sy;
-        actor.y = actor.baseY;
-      } else if (actor instanceof Butterfly) {
-        // Scale position and wander target
-        actor.x *= sx;
-        actor.y *= sy;
-        actor.targetX *= sx;
-        actor.targetY *= sy;
-      } else if (actor instanceof Rocket) {
-        // Projectiles in flight — scale position
-        actor.x *= sx;
-        actor.y *= sy;
+    for (let s = 0; s < this.sceneActors.length; s++) {
+      for (const actor of this.sceneActors[s]) {
+        if (actor instanceof LaunchPad) {
+          actor.x = newW * 0.5;
+          actor.y = newH * (s === 0 ? 0.72 : s === 1 ? 0.85 : 0.88);
+        } else if (actor instanceof Car) {
+          actor.x *= sx;
+          actor.y = newH * (actor.laneY || 0.82);
+        } else if (actor instanceof Ball) {
+          actor.x *= sx;
+          actor.y *= sy;
+        } else if (actor instanceof Star) {
+          actor.baseX *= sx;
+          actor.baseY *= sy;
+          actor.x = actor.baseX;
+          actor.y = actor.baseY;
+        } else if (actor instanceof Target) {
+          actor.x *= sx;
+          actor.baseY *= sy;
+          actor.y = actor.baseY;
+        } else if (actor instanceof Butterfly || actor instanceof Fish || actor instanceof Astronaut) {
+          actor.x *= sx;
+          actor.y *= sy;
+          if (actor.targetX !== undefined) {
+            actor.targetX *= sx;
+            actor.targetY *= sy;
+          }
+        } else if (actor instanceof Rocket) {
+          actor.x *= sx;
+          actor.y *= sy;
+        }
       }
     }
 
-    // Scale key label positions
     for (const l of this.keyLabels) {
       l.x *= sx;
       l.y *= sy;
@@ -326,6 +434,16 @@ export class World {
 
   _spawnTemporaryBall() {
     const b = new Ball(50 + Math.random() * (this.w - 100), this.h * 0.18);
+
+    // Adjust gravity for current scene
+    const sceneId = this.sceneManager.currentScene.id;
+    if (sceneId === 'space') {
+      b.gravity = 30;
+      b.bounciness = 0.9;
+    } else if (sceneId === 'underwater') {
+      b.gravity = 50;
+    }
+
     this.actors.push(b);
     setTimeout(() => { b.alive = false; }, 14000);
   }
@@ -359,21 +477,57 @@ export class World {
 
   draw() {
     const { ctx, w, h } = this;
+    const sm = this.sceneManager;
+    const currentIdx = sm.currentIndex;
+    const sceneId = SCENE_CONFIGS[currentIdx].id;
 
-    // Background
-    this.bg.draw(ctx, w, h);
+    if (sm.transitioning && sm.slideOffset !== 0) {
+      // During transition: draw current scene sliding in, previous scene sliding out
+      const offset = sm.slideOffset;
+      const dir = Math.sign(offset);
+      const prevIdx = currentIdx - dir; // the scene we came from
 
-    // World actors + particles
-    for (const actor of this.actors) actor.draw(ctx);
+      // Current scene position (sliding from offset towards 0)
+      const currentX = offset * w;
+      // Previous scene slides out in the opposite direction
+      const prevX = (offset - dir) * w;
+
+      // Draw previous scene
+      if (prevIdx >= 0 && prevIdx < SCENE_CONFIGS.length) {
+        ctx.save();
+        ctx.translate(prevX, 0);
+        ctx.beginPath();
+        ctx.rect(0, 0, w, h);
+        ctx.clip();
+        this.bg.draw(ctx, w, h, SCENE_CONFIGS[prevIdx].id);
+        for (const actor of this.sceneActors[prevIdx]) actor.draw(ctx);
+        ctx.restore();
+      }
+
+      // Draw current scene
+      ctx.save();
+      ctx.translate(currentX, 0);
+      ctx.beginPath();
+      ctx.rect(0, 0, w, h);
+      ctx.clip();
+      this.bg.draw(ctx, w, h, sceneId);
+      for (const actor of this.sceneActors[currentIdx]) actor.draw(ctx);
+      ctx.restore();
+    } else {
+      // Normal: draw current scene
+      this.bg.draw(ctx, w, h, sceneId);
+      for (const actor of this.actors) actor.draw(ctx);
+    }
+
+    // Particles, drawing, labels always on top
     this.particles.draw(ctx);
-
-    // Drawing layer on top of world, below key labels
     this.drawing.draw(ctx);
-
-    // Key labels — topmost
     for (const l of this.keyLabels) l.draw(ctx);
 
-    // ── Goal progress stars ────────────────────────────
+    // Goal progress stars
     this.goals.draw(ctx, w);
+
+    // Scene dot indicators
+    sm.drawIndicators(ctx, w, h);
   }
 }

--- a/src/actors/Astronaut.js
+++ b/src/actors/Astronaut.js
@@ -1,0 +1,88 @@
+import { Actor } from './Actor.js';
+
+const EMOJIS = ['🧑‍🚀', '🛸', '👽', '🪐', '🌙'];
+
+export class Astronaut extends Actor {
+  constructor(x, y) {
+    super(x, y);
+    this.size = 60;
+    this.emoji = EMOJIS[Math.floor(Math.random() * EMOJIS.length)];
+    this.targetX = x;
+    this.targetY = y;
+    this.wanderTimer = 0;
+    this.floatPhase = Math.random() * Math.PI * 2;
+    this.rotAngle = 0;
+    this.rotSpeed = (Math.random() - 0.5) * 0.4;
+    this._w = 800;
+    this._h = 600;
+  }
+
+  _pickNewTarget() {
+    this.targetX = 60 + Math.random() * (this._w - 120);
+    this.targetY = 50 + Math.random() * (this._h * 0.7);
+    this.wanderTimer = 3.0 + Math.random() * 4.0;
+  }
+
+  update(dt, w, h) {
+    super.update(dt, w, h);
+    this._w = w; this._h = h;
+
+    this.floatPhase += dt * 1.5;
+    this.rotAngle += this.rotSpeed * dt;
+
+    this.wanderTimer -= dt;
+    if (this.wanderTimer <= 0) this._pickNewTarget();
+
+    const dx = this.targetX - this.x;
+    const dy = this.targetY - this.y;
+    const dist = Math.hypot(dx, dy);
+
+    if (dist > 8) {
+      const accel = 40; // slow, floaty movement
+      this.vx += (dx / dist) * accel * dt * 2;
+      this.vy += (dy / dist) * accel * dt * 2;
+    }
+
+    this.vx *= 0.97;
+    this.vy *= 0.97;
+    this.x += this.vx * dt;
+    this.y += this.vy * dt;
+
+    // Gentle float
+    this.y += Math.sin(this.floatPhase) * 0.4;
+
+    this.x = Math.max(30, Math.min(w - 30, this.x));
+    this.y = Math.max(30, Math.min(h - 30, this.y));
+  }
+
+  draw(ctx) {
+    ctx.save();
+    ctx.translate(this.x, this.y);
+    ctx.rotate(this.rotAngle);
+    ctx.font = `${this.size}px serif`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(this.emoji, 0, 0);
+    ctx.restore();
+  }
+
+  onTap(x, y, particles, audio) {
+    if (this.tapCooldown > 0) return;
+    this.tapCooldown = 0.6;
+
+    const dx = this.x - x;
+    const dy = this.y - y;
+    const dist = Math.max(1, Math.hypot(dx, dy));
+    this.vx += (dx / dist) * 250;
+    this.vy += (dy / dist) * 250;
+    this.rotSpeed = (Math.random() - 0.5) * 3;
+    this.wanderTimer = 0;
+
+    particles.burst(this.x, this.y, 12, {
+      colors: ['#FFD700', '#E8EAF6', '#B388FF', '#82B1FF', '#FFFFFF'],
+      minSpeed: 40, maxSpeed: 130, gravity: 15,
+    });
+
+    audio.sparkle();
+  }
+}

--- a/src/actors/Fish.js
+++ b/src/actors/Fish.js
@@ -1,0 +1,90 @@
+import { Actor } from './Actor.js';
+
+const EMOJIS = ['🐠', '🐡', '🐟', '🐙', '🦑'];
+
+export class Fish extends Actor {
+  constructor(x, y) {
+    super(x, y);
+    this.size = 55;
+    this.emoji = EMOJIS[Math.floor(Math.random() * EMOJIS.length)];
+    this.targetX = x;
+    this.targetY = y;
+    this.wanderTimer = 0;
+    this.swimPhase = Math.random() * Math.PI * 2;
+    this.scaleX = 1;
+    this._w = 800;
+    this._h = 600;
+  }
+
+  _pickNewTarget() {
+    this.targetX = 60 + Math.random() * (this._w - 120);
+    this.targetY = 50 + Math.random() * (this._h * 0.75);
+    this.wanderTimer = 2.0 + Math.random() * 3.0;
+  }
+
+  update(dt, w, h) {
+    super.update(dt, w, h);
+    this._w = w; this._h = h;
+
+    this.swimPhase += dt * 5;
+
+    this.wanderTimer -= dt;
+    if (this.wanderTimer <= 0) this._pickNewTarget();
+
+    const dx = this.targetX - this.x;
+    const dy = this.targetY - this.y;
+    const dist = Math.hypot(dx, dy);
+
+    if (dist > 8) {
+      const accel = 70;
+      this.vx += (dx / dist) * accel * dt * 3;
+      this.vy += (dy / dist) * accel * dt * 3;
+    }
+
+    this.vx *= 0.95;
+    this.vy *= 0.95;
+    this.x += this.vx * dt;
+    this.y += this.vy * dt;
+
+    // Face direction of movement
+    if (Math.abs(this.vx) > 5) {
+      this.scaleX = this.vx > 0 ? 1 : -1;
+    }
+
+    // Gentle vertical wobble
+    this.y += Math.sin(this.swimPhase) * 0.3;
+
+    this.x = Math.max(30, Math.min(w - 30, this.x));
+    this.y = Math.max(30, Math.min(h - 30, this.y));
+  }
+
+  draw(ctx) {
+    ctx.save();
+    ctx.translate(this.x, this.y);
+    ctx.scale(this.scaleX, 1);
+    ctx.font = `${this.size}px serif`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(this.emoji, 0, 0);
+    ctx.restore();
+  }
+
+  onTap(x, y, particles, audio) {
+    if (this.tapCooldown > 0) return;
+    this.tapCooldown = 0.6;
+
+    const dx = this.x - x;
+    const dy = this.y - y;
+    const dist = Math.max(1, Math.hypot(dx, dy));
+    this.vx += (dx / dist) * 300;
+    this.vy += (dy / dist) * 300;
+    this.wanderTimer = 0;
+
+    particles.burst(this.x, this.y, 10, {
+      colors: ['#4FC3F7', '#81D4FA', '#B3E5FC', '#00BCD4', '#80DEEA'],
+      minSpeed: 40, maxSpeed: 110, gravity: 30,
+    });
+
+    audio.pop();
+  }
+}


### PR DESCRIPTION
## Summary
- Adds 3 themed scenes: **Road** (original), **Space** (dark starfield with astronauts, planets, nebula), and **Underwater** (blue-green gradient with fish, bubbles, seaweed, shark)
- Swipe left/right to navigate between scenes with smooth slide transitions
- Dot indicators at bottom center show current scene position
- Each scene has its own actors, launch pad, and targets; drawing and keyboard work in all scenes

## New files
- `src/SceneManager.js` — manages scene array, swipe detection, transition animation, dot indicators
- `src/actors/Fish.js` — swimming fish actor (similar to Butterfly AI) with underwater-themed emojis
- `src/actors/Astronaut.js` — floating space actor with slow drift and rotation

## Modified files
- `src/Background.js` — added `drawSpace()` and `drawUnderwater()` methods alongside original `drawRoad()`
- `src/World.js` — per-scene actor storage, scene-aware spawning/collision/resize, transition-aware rendering
- `src/InputManager.js` — added swipe event tracking for scene navigation

## Test plan
- [ ] Verify Road scene looks and behaves identically to before
- [ ] Swipe left to navigate to Space scene — verify stars, planets, astronauts render
- [ ] Swipe left again to Underwater scene — verify fish, bubbles, seaweed, shark render
- [ ] Swipe right to go back; verify dot indicators update
- [ ] Verify drawing works in all scenes
- [ ] Verify keyboard input works in all scenes
- [ ] Verify rockets launch and hit targets in all scenes
- [ ] Verify fast swipe is detected, slow drag is treated as drawing

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)