### PR TITLE
feat: add device tilt/accelerometer interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 ## What is it?
 
 A kid-safe fullscreen world where **every touch causes a friendly reaction**.
-For toddlers (2–3): pure cause and effect. For older kids (4–5): mini-goals, collectibles, and progression.
+For toddlers (2–3): pure cause and effect. For older kids (4–5): mini-goals with star progress, a collectible album, themed rooms to explore, and an owl companion that reacts alongside them.
 
 > "I touched something — and the world responded."
 
@@ -35,7 +35,7 @@ Works on phones, tablets, laptops. Fully offline. Zero ads. Zero links.
 | ⭐ **Stars** | Drift through the sky — tap for a golden sparkle burst |
 | 🦋 **Butterflies** | Wander freely — tap to scatter them away |
 | 🎨 **Drawing** | Drag a finger or mouse to paint glowing rainbow trails that fade |
-| ⌨️ **Keyboard** | Every key press shows a giant colorful floating letter with sound |
+| ⌨️ **Keyboard** | Every key press shows a giant colorful floating letter with spoken pronunciation |
 | 🌅 **Day/night cycle** | The world slowly cycles from dawn → noon → dusk → midnight |
 | 🎆 **Emergent events** | Random confetti, rainbow bursts, new actors appear spontaneously |
 | 🔇 **Synthesized audio** | All sounds generated via Web Audio API — no audio files needed |
@@ -43,6 +43,15 @@ Works on phones, tablets, laptops. Fully offline. Zero ads. Zero links.
 | 🚪 **Safe exit** | Hold top-right corner for 3 seconds to exit fullscreen |
 | 🎯 **Launch pad** | Aim and launch rockets at moving targets for points |
 | 💥 **Car crashes** | Cars can swerve into oncoming lane and crash with explosion effects |
+| 🏆 **Mini-goals** | Star progress bar — hit targets to fill stars, then celebrate with fanfare |
+| 🎵 **Background music** | Ambient pentatonic melodies that crossfade between day and night |
+| 📖 **Collectible album** | Tap the book icon to view collected target emojis with counts |
+| 🌍 **Themed rooms** | Swipe to explore Road, Space, and Underwater scenes |
+| 🦉 **Owl companion** | Friendly owl that celebrates hits, sleeps at night, and waves when idle |
+| 🐠 **Fish** | Underwater scene actors — swim around and scatter on tap |
+| 🧑‍🚀 **Astronaut** | Space scene actors — float and spin in zero gravity |
+| 🔊 **Letter speech** | Letters spoken aloud via Speech Synthesis API on key press |
+| 🎺 **Fanfare** | Triumphant ascending melody when a goal is completed |
 
 ---
 
@@ -52,14 +61,14 @@ Planned improvements to better engage children aged 4–5:
 
 | Priority | Feature | Issue |
 |----------|---------|-------|
-| 🔴 High | Mini-goals with celebrations | [#6](https://github.com/programmism/little-explorer-lab/issues/6) |
-| 🔴 High | Letter pronunciation on keypress | [#7](https://github.com/programmism/little-explorer-lab/issues/7) |
-| 🔴 High | Ambient background music (day/night) | [#8](https://github.com/programmism/little-explorer-lab/issues/8) |
-| 🔴 High | Fix tap vs drawing input conflict | [#9](https://github.com/programmism/little-explorer-lab/issues/9) |
-| 🟡 Medium | Themed rooms with swipe navigation | [#10](https://github.com/programmism/little-explorer-lab/issues/10) |
-| 🟡 Medium | Companion character | [#11](https://github.com/programmism/little-explorer-lab/issues/11) |
-| 🟡 Medium | Collectible album for targets | [#12](https://github.com/programmism/little-explorer-lab/issues/12) |
-| 🟡 Medium | Visual progress bar instead of score | [#13](https://github.com/programmism/little-explorer-lab/issues/13) |
+| ✅ Done | Mini-goals with celebrations | [#6](https://github.com/programmism/little-explorer-lab/issues/6) |
+| ✅ Done | Letter pronunciation on keypress | [#7](https://github.com/programmism/little-explorer-lab/issues/7) |
+| ✅ Done | Ambient background music (day/night) | [#8](https://github.com/programmism/little-explorer-lab/issues/8) |
+| ✅ Done | Fix tap vs drawing input conflict | [#9](https://github.com/programmism/little-explorer-lab/issues/9) |
+| ✅ Done | Themed rooms with swipe navigation | [#10](https://github.com/programmism/little-explorer-lab/issues/10) |
+| ✅ Done | Companion character | [#11](https://github.com/programmism/little-explorer-lab/issues/11) |
+| ✅ Done | Collectible album for targets | [#12](https://github.com/programmism/little-explorer-lab/issues/12) |
+| ✅ Done | Visual progress bar instead of score | [#13](https://github.com/programmism/little-explorer-lab/issues/13) |
 | 🟢 Low | Coloring mode with animated results | [#14](https://github.com/programmism/little-explorer-lab/issues/14) |
 | 🟢 Low | Musical instrument mode | [#15](https://github.com/programmism/little-explorer-lab/issues/15) |
 | 🟢 Low | Device tilt/accelerometer interactions | [#16](https://github.com/programmism/little-explorer-lab/issues/16) |

--- a/src/InputManager.js
+++ b/src/InputManager.js
@@ -24,7 +24,12 @@ export class InputManager {
     this._exitOverlay = document.getElementById('exit-overlay');
     this._exitCountdown = document.getElementById('exit-countdown');
 
+    // Device tilt (accelerometer) — normalized to roughly -1..1
+    this._tilt = { x: 0, y: 0 };
+    this._tiltAvailable = false;
+
     this._bindEvents();
+    this._bindTilt();
   }
 
   _bindEvents() {
@@ -207,6 +212,42 @@ export class InputManager {
       this._exitTimer = null;
     }
     this._exitOverlay.classList.remove('visible');
+  }
+
+  _bindTilt() {
+    if (typeof DeviceOrientationEvent === 'undefined') return;
+
+    const listen = () => {
+      window.addEventListener('deviceorientation', (e) => {
+        // gamma: left-right tilt (-90..90), beta: front-back tilt (-180..180)
+        if (e.gamma == null || e.beta == null) return;
+        this._tiltAvailable = true;
+        // Normalize to roughly -1..1 (clamp at ±45 degrees)
+        this._tilt = {
+          x: Math.max(-1, Math.min(1, e.gamma / 45)),
+          y: Math.max(-1, Math.min(1, (e.beta - 45) / 45)),
+        };
+      });
+    };
+
+    // iOS 13+ requires explicit permission request
+    if (typeof DeviceOrientationEvent.requestPermission === 'function') {
+      // Attach a one-time user-gesture handler to request permission
+      const requestOnce = () => {
+        DeviceOrientationEvent.requestPermission()
+          .then(state => { if (state === 'granted') listen(); })
+          .catch(() => {});
+        window.removeEventListener('touchstart', requestOnce);
+      };
+      window.addEventListener('touchstart', requestOnce);
+    } else {
+      listen();
+    }
+  }
+
+  /** Returns current device tilt as {x, y} in roughly -1..1 range. */
+  getTilt() {
+    return this._tilt;
   }
 
   consumeSwipeEvents() {

--- a/src/World.js
+++ b/src/World.js
@@ -340,10 +340,27 @@ export class World {
     this.keyLabels = this.keyLabels.filter(l => l.alive);
     for (const l of this.keyLabels) l.update(dt);
 
+    // ── Device tilt → actor forces ───────────────────────
+    const tilt = this.input.getTilt();
+
     // ── Update actors for ALL scenes (so they stay alive) ──
     for (let s = 0; s < this.sceneActors.length; s++) {
       for (const actor of this.sceneActors[s]) {
         actor.update(dt, this.w, this.h, this.particles);
+
+        // Apply tilt forces to specific actor types
+        if (tilt.x !== 0 || tilt.y !== 0) {
+          if (actor instanceof Ball) {
+            actor.vx += tilt.x * 200 * dt;
+            actor.vy += tilt.y * 200 * dt;
+          } else if (actor instanceof Butterfly || actor instanceof Fish) {
+            actor.targetX += tilt.x * 30 * dt;
+            actor.targetY += tilt.y * 30 * dt;
+          } else if (actor instanceof Star) {
+            actor.tiltOffsetX = tilt.x * 20;
+            actor.tiltOffsetY = tilt.y * 20;
+          }
+        }
       }
     }
 

--- a/src/actors/Star.js
+++ b/src/actors/Star.js
@@ -13,6 +13,8 @@ export class Star extends Actor {
     this.scaleTarget = 1;
     this.hidden = false;
     this.hideTimer = 0;
+    this.tiltOffsetX = 0;
+    this.tiltOffsetY = 0;
   }
 
   update(dt, w, h) {
@@ -40,7 +42,7 @@ export class Star extends Actor {
   draw(ctx) {
     if (this.scale < 0.01) return;
     ctx.save();
-    ctx.translate(this.x, this.y);
+    ctx.translate(this.x + this.tiltOffsetX, this.y + this.tiltOffsetY);
     ctx.rotate(this.rotAngle);
     ctx.scale(this.scale, this.scale);
     ctx.font = `${this.size}px serif`;


### PR DESCRIPTION
## Summary
- Add DeviceOrientation API support to `InputManager` with `getTilt()` returning normalized `{x, y}` in -1..1 range
- Balls receive tilt as acceleration, butterflies/fish drift wander targets with tilt, stars get parallax visual offset
- Graceful fallback: defaults to `{x:0, y:0}` on desktop (no-op), handles iOS permission request automatically

Closes #16

## Test plan
- [ ] On mobile device: tilt device and verify balls roll in tilt direction
- [ ] On mobile device: verify butterflies/fish drift with tilt
- [ ] On mobile device: verify stars shift with parallax effect
- [ ] On desktop: verify no behavioral changes (tilt defaults to zero)
- [ ] On iOS Safari: verify permission prompt appears on first touch

🤖 Generated with [Claude Code](https://claude.com/claude-code)