### PR TITLE
feat: add musical instrument mode

### DIFF
--- a/src/AudioManager.js
+++ b/src/AudioManager.js
@@ -139,6 +139,46 @@ export class AudioManager {
     }, 160);
   }
 
+  /**
+   * Play a marimba-like note at the given frequency.
+   * Uses a triangle wave with a quick ADSR envelope for a warm, mallet tone.
+   */
+  playNote(freq) {
+    if (!this._ctx) return;
+    const ctx = this._ctx;
+    const now = ctx.currentTime;
+
+    // Primary triangle oscillator (warm mallet tone)
+    const osc1 = ctx.createOscillator();
+    const gain1 = ctx.createGain();
+    osc1.type = 'triangle';
+    osc1.frequency.setValueAtTime(freq, now);
+    osc1.connect(gain1);
+    gain1.connect(ctx.destination);
+
+    // ADSR: fast attack, short decay, low sustain, medium release
+    gain1.gain.setValueAtTime(0, now);
+    gain1.gain.linearRampToValueAtTime(0.45, now + 0.01);   // attack
+    gain1.gain.exponentialRampToValueAtTime(0.15, now + 0.15); // decay
+    gain1.gain.exponentialRampToValueAtTime(0.001, now + 0.8); // release
+    osc1.start(now);
+    osc1.stop(now + 0.8);
+
+    // Harmonic layer (sine at 2x frequency) for brightness
+    const osc2 = ctx.createOscillator();
+    const gain2 = ctx.createGain();
+    osc2.type = 'sine';
+    osc2.frequency.setValueAtTime(freq * 2, now);
+    osc2.connect(gain2);
+    gain2.connect(ctx.destination);
+
+    gain2.gain.setValueAtTime(0, now);
+    gain2.gain.linearRampToValueAtTime(0.12, now + 0.005);
+    gain2.gain.exponentialRampToValueAtTime(0.001, now + 0.3);
+    osc2.start(now);
+    osc2.stop(now + 0.3);
+  }
+
   fanfare() {
     // Triumphant ascending fanfare for goal completion
     const notes = [

--- a/src/Background.js
+++ b/src/Background.js
@@ -370,12 +370,46 @@ export class Background {
     ctx.restore();
   }
 
+  /** Draw the music scene — dark stage with subtle spotlight. */
+  drawMusic(ctx, w, h) {
+    // Dark stage gradient
+    const grad = ctx.createLinearGradient(0, 0, 0, h);
+    grad.addColorStop(0, '#1a0a2e');
+    grad.addColorStop(0.4, '#16213e');
+    grad.addColorStop(1, '#0a0a1a');
+    ctx.fillStyle = grad;
+    ctx.fillRect(0, 0, w, h);
+
+    // Soft spotlight from above
+    ctx.save();
+    ctx.globalAlpha = 0.07;
+    const spot = ctx.createRadialGradient(w * 0.5, 0, 0, w * 0.5, h * 0.3, w * 0.5);
+    spot.addColorStop(0, '#ffffff');
+    spot.addColorStop(1, 'transparent');
+    ctx.fillStyle = spot;
+    ctx.fillRect(0, 0, w, h);
+    ctx.restore();
+
+    // Faint twinkling stars for ambiance
+    ctx.fillStyle = '#ffffff';
+    for (const s of this.spaceStars) {
+      if (s.y > 0.45) continue; // only upper portion
+      ctx.globalAlpha = 0.15 + 0.2 * Math.abs(Math.sin(s.phase));
+      ctx.beginPath();
+      ctx.arc(s.x * w, s.y * h, s.r * 0.6, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    ctx.globalAlpha = 1;
+  }
+
   /** Main draw dispatcher based on scene ID. */
   draw(ctx, w, h, sceneId) {
     if (sceneId === 'space') {
       this.drawSpace(ctx, w, h);
     } else if (sceneId === 'underwater') {
       this.drawUnderwater(ctx, w, h);
+    } else if (sceneId === 'music') {
+      this.drawMusic(ctx, w, h);
     } else {
       this.drawRoad(ctx, w, h);
     }

--- a/src/MusicScene.js
+++ b/src/MusicScene.js
@@ -1,0 +1,224 @@
+/**
+ * MusicScene — a xylophone-style musical instrument scene.
+ *
+ * Seven colorful bars at the bottom of the screen play notes in a
+ * C-based pentatonic-ish scale (C D E G A highC highD) when tapped.
+ * Visual feedback includes bar glow, upward particle bursts, and
+ * floating note emojis that drift upward.
+ */
+
+// Frequencies for C4 pentatonic + high C5, D5
+const NOTES = [
+  { freq: 261.63, color: '#FF0000', label: 'C'  },  // red
+  { freq: 293.66, color: '#FF7F00', label: 'D'  },  // orange
+  { freq: 329.63, color: '#FFD700', label: 'E'  },  // yellow
+  { freq: 392.00, color: '#00CC44', label: 'G'  },  // green
+  { freq: 440.00, color: '#0077FF', label: 'A'  },  // blue
+  { freq: 523.25, color: '#4B0082', label: 'C\'' }, // indigo
+  { freq: 587.33, color: '#8B00FF', label: 'D\'' }, // violet
+];
+
+export class MusicScene {
+  constructor() {
+    this.bars = NOTES.map((n, i) => ({
+      ...n,
+      index: i,
+      glow: 0,       // 0-1, quick decay visual feedback
+    }));
+
+    // Floating note emojis
+    this.floatingNotes = []; // { x, y, vy, alpha, emoji }
+  }
+
+  /** Return the bounding rect of bar `i` given canvas size. */
+  _barRect(i, w, h) {
+    const count = this.bars.length;
+    const totalW = w * 0.88;
+    const gap = totalW * 0.02;
+    const barW = (totalW - gap * (count - 1)) / count;
+    const startX = (w - totalW) / 2;
+    const barH = h * 0.38;
+    const barY = h - barH - h * 0.06; // leave room for dot indicators
+
+    return {
+      x: startX + i * (barW + gap),
+      y: barY,
+      w: barW,
+      h: barH,
+    };
+  }
+
+  /**
+   * Test if (tx,ty) hits a bar. Returns the bar index or -1.
+   */
+  hitTest(tx, ty, w, h) {
+    for (let i = 0; i < this.bars.length; i++) {
+      const r = this._barRect(i, w, h);
+      if (tx >= r.x && tx <= r.x + r.w && ty >= r.y && ty <= r.y + r.h) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  /**
+   * Called from World when a tap lands in the music scene.
+   * Plays the note and triggers visual feedback.
+   */
+  play(index, audio, particles) {
+    const bar = this.bars[index];
+    if (!bar) return;
+
+    // Sound
+    audio.playNote(bar.freq);
+
+    // Visual: glow
+    bar.glow = 1;
+
+    // Visual: particle burst upward from bar centre
+    // (we need canvas dimensions — stored on last draw)
+    if (this._lastW) {
+      const r = this._barRect(index, this._lastW, this._lastH);
+      const cx = r.x + r.w / 2;
+      const cy = r.y;
+      particles.burst(cx, cy, 10, {
+        colors: [bar.color, '#FFFFFF', lighten(bar.color)],
+        minSpeed: 60,
+        maxSpeed: 200,
+        gravity: 100,
+      });
+
+      // Floating note emoji
+      const emojis = ['🎵', '🎶'];
+      this.floatingNotes.push({
+        x: cx + (Math.random() - 0.5) * r.w * 0.4,
+        y: cy,
+        vy: -60 - Math.random() * 40,
+        alpha: 1,
+        emoji: emojis[Math.floor(Math.random() * emojis.length)],
+        size: 24 + Math.random() * 16,
+      });
+    }
+  }
+
+  update(dt) {
+    // Decay bar glow
+    for (const bar of this.bars) {
+      if (bar.glow > 0) {
+        bar.glow = Math.max(0, bar.glow - dt * 4);
+      }
+    }
+
+    // Update floating notes
+    for (const note of this.floatingNotes) {
+      note.y += note.vy * dt;
+      note.alpha -= dt * 0.6;
+    }
+    this.floatingNotes = this.floatingNotes.filter(n => n.alpha > 0);
+  }
+
+  draw(ctx, w, h) {
+    this._lastW = w;
+    this._lastH = h;
+
+    // ── Floating note emojis (behind bars so they appear to rise) ──
+    ctx.save();
+    for (const note of this.floatingNotes) {
+      ctx.globalAlpha = Math.max(0, note.alpha);
+      ctx.font = `${note.size}px serif`;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(note.emoji, note.x, note.y);
+    }
+    ctx.globalAlpha = 1;
+    ctx.restore();
+
+    // ── Draw bars ──────────────────────────────────────────────
+    for (let i = 0; i < this.bars.length; i++) {
+      const bar = this.bars[i];
+      const r = this._barRect(i, w, h);
+
+      ctx.save();
+
+      // Glow aura when active
+      if (bar.glow > 0.01) {
+        ctx.shadowColor = bar.color;
+        ctx.shadowBlur = 30 * bar.glow;
+      }
+
+      // Bar fill — gradient top to bottom
+      const grad = ctx.createLinearGradient(r.x, r.y, r.x, r.y + r.h);
+      const bright = bar.glow > 0.01 ? lighten(bar.color) : bar.color;
+      grad.addColorStop(0, bright);
+      grad.addColorStop(1, darken(bar.color));
+      ctx.fillStyle = grad;
+
+      // Rounded rect
+      roundRect(ctx, r.x, r.y, r.w, r.h, 10);
+      ctx.fill();
+
+      // Subtle border
+      ctx.strokeStyle = 'rgba(255,255,255,0.25)';
+      ctx.lineWidth = 2;
+      roundRect(ctx, r.x, r.y, r.w, r.h, 10);
+      ctx.stroke();
+
+      ctx.shadowBlur = 0;
+
+      // Ripple ring when freshly tapped
+      if (bar.glow > 0.3) {
+        const rippleR = r.w * 0.6 * (1 - bar.glow) + r.w * 0.3;
+        ctx.globalAlpha = bar.glow * 0.5;
+        ctx.strokeStyle = bar.color;
+        ctx.lineWidth = 3;
+        ctx.beginPath();
+        ctx.arc(r.x + r.w / 2, r.y + r.h * 0.3, rippleR, 0, Math.PI * 2);
+        ctx.stroke();
+        ctx.globalAlpha = 1;
+      }
+
+      // Note label at bottom of bar
+      ctx.fillStyle = 'rgba(255,255,255,0.85)';
+      ctx.font = `bold ${Math.max(14, r.w * 0.32)}px sans-serif`;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'bottom';
+      ctx.fillText(bar.label, r.x + r.w / 2, r.y + r.h - 8);
+
+      ctx.restore();
+    }
+  }
+}
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function roundRect(ctx, x, y, w, h, radius) {
+  ctx.beginPath();
+  ctx.moveTo(x + radius, y);
+  ctx.lineTo(x + w - radius, y);
+  ctx.arcTo(x + w, y, x + w, y + radius, radius);
+  ctx.lineTo(x + w, y + h - radius);
+  ctx.arcTo(x + w, y + h, x + w - radius, y + h, radius);
+  ctx.lineTo(x + radius, y + h);
+  ctx.arcTo(x, y + h, x, y + h - radius, radius);
+  ctx.lineTo(x, y + radius);
+  ctx.arcTo(x, y, x + radius, y, radius);
+  ctx.closePath();
+}
+
+/** Lighten a hex colour for glow effects. */
+function lighten(hex) {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  const mix = (c) => Math.min(255, c + 80);
+  return `rgb(${mix(r)},${mix(g)},${mix(b)})`;
+}
+
+/** Darken a hex colour for bar gradient bottom. */
+function darken(hex) {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  const mix = (c) => Math.max(0, c - 50);
+  return `rgb(${mix(r)},${mix(g)},${mix(b)})`;
+}

--- a/src/SceneManager.js
+++ b/src/SceneManager.js
@@ -7,6 +7,7 @@
 export const SCENE_ROAD = 0;
 export const SCENE_SPACE = 1;
 export const SCENE_UNDERWATER = 2;
+export const SCENE_MUSIC = 3;
 
 export const SCENE_CONFIGS = [
   {
@@ -20,6 +21,10 @@ export const SCENE_CONFIGS = [
   {
     id: 'underwater',
     name: 'Underwater',
+  },
+  {
+    id: 'music',
+    name: 'Music',
   },
 ];
 

--- a/src/World.js
+++ b/src/World.js
@@ -15,6 +15,7 @@ import { Companion } from './actors/Companion.js';
 import { GoalManager } from './GoalManager.js';
 import { CollectionManager } from './CollectionManager.js';
 import { SceneManager, SCENE_CONFIGS } from './SceneManager.js';
+import { MusicScene } from './MusicScene.js';
 
 export class World {
   constructor(canvas, ctx, input, audio) {
@@ -33,6 +34,7 @@ export class World {
     this.sceneLaunchPads = SCENE_CONFIGS.map(() => null);
 
     this.sceneManager = new SceneManager();
+    this.musicScene = new MusicScene();
 
     this._prevPointerIds = new Set();
 
@@ -272,6 +274,15 @@ export class World {
         continue;
       }
 
+      // ── Music scene: check xylophone bar taps first ──
+      if (this.sceneManager.currentScene.id === 'music') {
+        const barIdx = this.musicScene.hitTest(tap.x, tap.y, this.w, this.h);
+        if (barIdx >= 0) {
+          this.musicScene.play(barIdx, this.audio, this.particles);
+          continue;
+        }
+      }
+
       let hit = false;
       for (let i = this.actors.length - 1; i >= 0; i--) {
         const actor = this.actors[i];
@@ -339,6 +350,9 @@ export class World {
 
     this.keyLabels = this.keyLabels.filter(l => l.alive);
     for (const l of this.keyLabels) l.update(dt);
+
+    // ── Music scene animations ──────────────────────────
+    this.musicScene.update(dt);
 
     // ── Update actors for ALL scenes (so they stay alive) ──
     for (let s = 0; s < this.sceneActors.length; s++) {
@@ -544,6 +558,7 @@ export class World {
         ctx.clip();
         this.bg.draw(ctx, w, h, SCENE_CONFIGS[prevIdx].id);
         for (const actor of this.sceneActors[prevIdx]) actor.draw(ctx);
+        if (SCENE_CONFIGS[prevIdx].id === 'music') this.musicScene.draw(ctx, w, h);
         ctx.restore();
       }
 
@@ -555,11 +570,13 @@ export class World {
       ctx.clip();
       this.bg.draw(ctx, w, h, sceneId);
       for (const actor of this.sceneActors[currentIdx]) actor.draw(ctx);
+      if (sceneId === 'music') this.musicScene.draw(ctx, w, h);
       ctx.restore();
     } else {
       // Normal: draw current scene
       this.bg.draw(ctx, w, h, sceneId);
       for (const actor of this.actors) actor.draw(ctx);
+      if (sceneId === 'music') this.musicScene.draw(ctx, w, h);
     }
 
     // Particles, drawing, labels always on top


### PR DESCRIPTION
## Summary
- Add a new xylophone scene (4th scene, accessible via swipe) with 7 colorful bars playing C pentatonic scale notes (C D E G A C' D')
- Each bar plays a marimba-like tone (triangle wave + harmonic layer with ADSR envelope) via Web Audio API
- Visual feedback on tap: bar glow effect, upward particle bursts, ripple rings, and floating note emojis that drift upward
- Dark stage background with subtle spotlight and twinkling stars for ambiance
- Bars colored in rainbow order (red, orange, yellow, green, blue, indigo, violet) with gradient fills and rounded corners

## Files changed
- `src/MusicScene.js` — new scene with bar rendering, hit detection, note playback, and visual effects
- `src/AudioManager.js` — added `playNote(freq)` method with triangle oscillator and quick ADSR envelope
- `src/SceneManager.js` — added music scene config as 4th scene
- `src/Background.js` — added `drawMusic()` dark stage background
- `src/World.js` — integrated MusicScene for update/draw/tap handling

## Test plan
- [ ] Swipe to the 4th scene from underwater — music scene appears with dark stage background
- [ ] Tap each of the 7 bars — each plays a distinct note at correct pitch
- [ ] Visual feedback: bar glows on tap, particles burst upward, floating note emojis appear
- [ ] Swipe back and forth — transitions animate smoothly with music scene
- [ ] Scene dot indicators show 4 dots with correct active state

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)